### PR TITLE
Add macOS support with DMG installer handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,34 @@ jobs:
           "$RACKUP_HOME/shims/racket" -e '(displayln "hello from rackup")'
           bin/rackup remove "$(bin/rackup list --ids | head -1)"
 
+  macos-e2e-legacy-plt-dmg:
+    name: macOS E2E (legacy PLT Scheme DMG)
+    runs-on: macos-13
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Racket
+        uses: Bogdanp/setup-racket@v1.14
+        with:
+          architecture: x64
+          distribution: full
+          variant: CS
+          version: stable
+      - name: Build
+        shell: bash
+        run: raco make libexec/rackup-core.rkt libexec/rackup/*.rkt
+      - name: Legacy PLT Scheme DMG install (4.2.5, 4.0, 350)
+        shell: bash
+        run: |
+          export RACKUP_HOME="$(mktemp -d)/rackup-legacy"
+          for ver in 4.2.5 4.0 350; do
+            echo "=== Installing PLT Scheme $ver (macOS DMG) ==="
+            bin/rackup install "$ver" --arch i386 --verbose
+            bin/rackup list
+            echo "--- Installed $ver successfully ---"
+            bin/rackup remove "$(bin/rackup list --ids | tail -1)"
+          done
+
   macos-e2e-bootstrap:
     name: "macOS E2E Bootstrap (${{ matrix.runner }})"
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,23 +361,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # tgz installer path (preferred) — all macOS versions/archs
+          # tgz installer path — Intel has full tgz, ARM only has minimal tgz
           - runner: macos-13       # Intel x86_64
             installer_format: tgz
             setup_racket_arch: x64
+            extra_install_flags: ""
           - runner: macos-14       # Apple Silicon arm64
             installer_format: tgz
             setup_racket_arch: arm64
+            extra_install_flags: "--distribution minimal"
           - runner: macos-15       # Apple Silicon arm64
             installer_format: tgz
             setup_racket_arch: arm64
-          # dmg installer path (fallback) — test on one Intel + one ARM
+            extra_install_flags: "--distribution minimal"
+          # dmg installer path — test on one Intel + one ARM
           - runner: macos-13       # Intel x86_64
             installer_format: dmg
             setup_racket_arch: x64
+            extra_install_flags: ""
           - runner: macos-14       # Apple Silicon arm64
             installer_format: dmg
             setup_racket_arch: arm64
+            extra_install_flags: ""
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -395,7 +400,7 @@ jobs:
         shell: bash
         run: |
           export RACKUP_HOME="$(mktemp -d)/rackup-e2e"
-          bin/rackup install stable --set-default --installer-ext "${{ matrix.installer_format }}"
+          bin/rackup install stable --set-default --installer-ext "${{ matrix.installer_format }}" ${{ matrix.extra_install_flags }}
           bin/rackup list
           bin/rackup doctor
           "$RACKUP_HOME/shims/racket" -e '(displayln "hello from rackup")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
           - runs_on: ubuntu-24.04-arm
             arch_name: arm64
             setup_racket_arch: arm64
+          - runs_on: macos-13
+            arch_name: x64-macos
+            setup_racket_arch: x64
+          - runs_on: macos-14
+            arch_name: arm64-macos-14
+            setup_racket_arch: arm64
+          - runs_on: macos-15
+            arch_name: arm64-macos-15
+            setup_racket_arch: arm64
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -305,3 +314,70 @@ jobs:
             --source-build-commit 657a006747c199241b2569b56e07f26585eb0437 \
             --source-build-target base \
             --source-build-jobs "$(nproc)"
+
+  macos-e2e:
+    name: "macOS E2E (${{ matrix.runner }} / ${{ matrix.installer_format }})"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # tgz installer path (preferred) — all macOS versions/archs
+          - runner: macos-13       # Intel x86_64
+            installer_format: tgz
+            setup_racket_arch: x64
+          - runner: macos-14       # Apple Silicon arm64
+            installer_format: tgz
+            setup_racket_arch: arm64
+          - runner: macos-15       # Apple Silicon arm64
+            installer_format: tgz
+            setup_racket_arch: arm64
+          # dmg installer path (fallback) — test on one Intel + one ARM
+          - runner: macos-13       # Intel x86_64
+            installer_format: dmg
+            setup_racket_arch: x64
+          - runner: macos-14       # Apple Silicon arm64
+            installer_format: dmg
+            setup_racket_arch: arm64
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Racket
+        uses: Bogdanp/setup-racket@v1.14
+        with:
+          architecture: ${{ matrix.setup_racket_arch }}
+          distribution: full
+          variant: CS
+          version: stable
+      - name: Build
+        shell: bash
+        run: raco make libexec/rackup-core.rkt libexec/rackup/*.rkt
+      - name: "E2E install stable (${{ matrix.installer_format }})"
+        shell: bash
+        run: |
+          export RACKUP_HOME="$(mktemp -d)/rackup-e2e"
+          bin/rackup install stable --set-default --installer-ext "${{ matrix.installer_format }}"
+          bin/rackup list
+          bin/rackup doctor
+          "$RACKUP_HOME/shims/racket" -e '(displayln "hello from rackup")'
+          bin/rackup remove "$(bin/rackup list --ids | head -1)"
+
+  macos-e2e-bootstrap:
+    name: "macOS E2E Bootstrap (${{ matrix.runner }})"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-13       # Intel x86_64
+          - runner: macos-14       # Apple Silicon arm64
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bootstrap install (no system racket)
+        shell: bash
+        run: |
+          export RACKUP_HOME="$(mktemp -d)/rackup-bootstrap"
+          sh scripts/install.sh -y --from-local . --prefix "$RACKUP_HOME"
+          "$RACKUP_HOME/bin/rackup" install stable --set-default
+          "$RACKUP_HOME/shims/racket" -e '(displayln "bootstrap ok")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
           bin/rackup list
           bin/rackup doctor
           "$RACKUP_HOME/shims/racket" -e '(displayln "hello from rackup")'
-          bin/rackup remove "$(bin/rackup list | awk 'NR==1{print $2}')"
+          bin/rackup remove "$(bin/rackup list --ids | head -1)"
 
   macos-e2e-legacy-plt-dmg:
     name: macOS E2E (legacy PLT Scheme DMG)
@@ -431,7 +431,7 @@ jobs:
             bin/rackup install "$ver" --arch i386 --verbose
             bin/rackup list
             echo "--- Installed $ver successfully ---"
-            bin/rackup remove "$(bin/rackup list | awk 'END{print $2}')"
+            bin/rackup remove "$(bin/rackup list --ids | tail -1)"
           done
 
   macos-e2e-bootstrap:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
           bin/rackup list
           bin/rackup doctor
           "$RACKUP_HOME/shims/racket" -e '(displayln "hello from rackup")'
-          bin/rackup remove "$(bin/rackup list --ids | head -1)"
+          bin/rackup remove "$(bin/rackup list | awk 'NR==1{print $2}')"
 
   macos-e2e-legacy-plt-dmg:
     name: macOS E2E (legacy PLT Scheme DMG)
@@ -431,7 +431,7 @@ jobs:
             bin/rackup install "$ver" --arch i386 --verbose
             bin/rackup list
             echo "--- Installed $ver successfully ---"
-            bin/rackup remove "$(bin/rackup list --ids | tail -1)"
+            bin/rackup remove "$(bin/rackup list | awk 'END{print $2}')"
           done
 
   macos-e2e-bootstrap:

--- a/libexec/rackup-bootstrap.sh
+++ b/libexec/rackup-bootstrap.sh
@@ -224,6 +224,19 @@ rackup_fetch_text() {
   rm -f "$tmp"
 }
 
+rackup_host_platform() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin) echo "macosx" ;;
+    Linux)  echo "linux" ;;
+    # TODO: BSD (FreeBSD, OpenBSD, NetBSD) also uses sh/tgz installers like Linux.
+    # When BSD support is added, decide whether to return "linux" (shared installer
+    # mechanics) or a distinct token like "freebsd" (matching Racket download filenames).
+    *)
+      rackup_fail "unsupported platform: $(uname -s)"
+      ;;
+  esac
+}
+
 rackup_normalized_arch() {
   m="$(uname -m 2>/dev/null || echo unknown)"
   case "$m" in
@@ -247,16 +260,31 @@ rackup_lookup_stable_version_shell() {
 rackup_select_hidden_runtime_filename() {
   version="$1"
   arch="$2"
+  host_platform="$(rackup_host_platform)"
   table_url="https://download.racket-lang.org/installers/$version/table.rktd"
   table="$(rackup_fetch_text "$table_url")" || rackup_fail "failed to fetch $table_url"
 
   # Extract candidate installers from table.rktd conservatively.
-  candidates="$(printf '%s\n' "$table" | grep -Eo 'racket(-minimal)?-[^"[:space:]]+\.(sh|tgz)' | sort -u || true)"
+  # On Linux: look for .sh and .tgz; on macOS: look for .tgz and .dmg
+  case "$host_platform" in
+    macosx)
+      candidates="$(printf '%s\n' "$table" | grep -Eo 'racket(-minimal)?-[^"[:space:]]+\.(tgz|dmg)' | sort -u || true)"
+      ;;
+    *)
+      candidates="$(printf '%s\n' "$table" | grep -Eo 'racket(-minimal)?-[^"[:space:]]+\.(sh|tgz)' | sort -u || true)"
+      ;;
+  esac
   [ -n "$candidates" ] || rackup_fail "failed to parse installer candidates from $table_url"
+
+  # Set extension preference order based on platform
+  case "$host_platform" in
+    macosx)  want_exts="tgz dmg" ;;
+    *)       want_exts="sh tgz" ;;
+  esac
 
   found=""
   for want_variant in cs bc; do
-    for want_ext in sh tgz; do
+    for want_ext in $want_exts; do
       for f in $candidates; do
         case "$f" in
           racket-minimal-*."$want_ext") ;;
@@ -291,10 +319,23 @@ rackup_select_hidden_runtime_filename() {
         esac
         [ "$variant" = "$want_variant" ] || continue
 
-        case "$platform_token" in
-          linux|linux-*)
+        case "$host_platform" in
+          linux)
             case "$platform_token" in
-              *natipkg*|*pkg-build*) continue ;;
+              linux|linux-*)
+                case "$platform_token" in
+                  *natipkg*|*pkg-build*) continue ;;
+                esac
+                ;;
+              *)
+                continue
+                ;;
+            esac
+            ;;
+          macosx)
+            case "$platform_token" in
+              macosx|macosx-*) ;;
+              *) continue ;;
             esac
             ;;
           *)
@@ -308,7 +349,7 @@ rackup_select_hidden_runtime_filename() {
     done
   done
 
-  [ -n "$found" ] || rackup_fail "no matching hidden runtime installer found for stable=$version arch=$arch"
+  [ -n "$found" ] || rackup_fail "no matching hidden runtime installer found for stable=$version arch=$arch platform=$host_platform"
   printf '%s\n' "$found"
 }
 
@@ -381,7 +422,7 @@ rackup_hidden_runtime_install_if_missing() {
   runtime_variant="$(rackup_runtime_variant_from_filename "$filename")"
   runtime_ext="${filename##*.}"
   installer_url="https://download.racket-lang.org/installers/$stable_ver/$filename"
-  runtime_id="runtime-$stable_ver-$runtime_variant-$arch-linux-minimal"
+  runtime_id="runtime-$stable_ver-$runtime_variant-$arch-$(rackup_host_platform)-minimal"
   version_dir="$versions_dir/$runtime_id"
   tmp_version_dir="$versions_dir/.${runtime_id}.tmp.$$"
   install_root="$tmp_version_dir/install"
@@ -424,6 +465,42 @@ rackup_hidden_runtime_install_if_missing() {
         rm -rf "$tmp_version_dir"
         rackup_fail "hidden runtime archive extraction failed"
       fi
+      ;;
+    dmg)
+      dmg_mount="$(mktemp -d "${TMPDIR:-/tmp}/rackup-dmg.XXXXXX")"
+      if ! hdiutil attach -nobrowse -noverify -noautoopen -mountpoint "$dmg_mount" "$installer_cache" >/dev/null 2>&1; then
+        rm -rf "$dmg_mount" "$tmp_version_dir"
+        rackup_fail "failed to mount DMG installer"
+      fi
+      mkdir -p "$install_root"
+      # Racket .dmg files contain a top-level directory (e.g. "Racket v9.1/")
+      # with the standard bin/, lib/, share/ layout inside.
+      src_dir=""
+      for d in "$dmg_mount"/*/; do
+        if [ -d "${d}bin" ]; then
+          src_dir="$d"
+          break
+        fi
+      done
+      if [ -z "$src_dir" ]; then
+        if [ -d "$dmg_mount/bin" ]; then
+          src_dir="$dmg_mount/"
+        else
+          # Fall back to first directory
+          for d in "$dmg_mount"/*/; do
+            src_dir="$d"
+            break
+          done
+        fi
+      fi
+      if [ -z "$src_dir" ]; then
+        hdiutil detach "$dmg_mount" -quiet 2>/dev/null || true
+        rm -rf "$dmg_mount" "$tmp_version_dir"
+        rackup_fail "could not find Racket installation inside DMG"
+      fi
+      cp -R "$src_dir"/* "$install_root/" 2>/dev/null || cp -R "$src_dir". "$install_root/" 2>/dev/null || true
+      hdiutil detach "$dmg_mount" -quiet 2>/dev/null || true
+      rm -rf "$dmg_mount"
       ;;
     *)
       rm -rf "$tmp_version_dir"

--- a/libexec/rackup-bootstrap.sh
+++ b/libexec/rackup-bootstrap.sh
@@ -227,7 +227,7 @@ rackup_fetch_text() {
 rackup_host_platform() {
   case "$(uname -s 2>/dev/null)" in
     Darwin) echo "macosx" ;;
-    Linux)  echo "linux" ;;
+    Linux) echo "linux" ;;
     # TODO: BSD (FreeBSD, OpenBSD, NetBSD) also uses sh/tgz installers like Linux.
     # When BSD support is added, decide whether to return "linux" (shared installer
     # mechanics) or a distinct token like "freebsd" (matching Racket download filenames).
@@ -278,8 +278,8 @@ rackup_select_hidden_runtime_filename() {
 
   # Set extension preference order based on platform
   case "$host_platform" in
-    macosx)  want_exts="tgz dmg" ;;
-    *)       want_exts="sh tgz" ;;
+    macosx) want_exts="tgz dmg" ;;
+    *) want_exts="sh tgz" ;;
   esac
 
   found=""

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -199,7 +199,7 @@
   (dynamic-wind
    (lambda ()
      (system*/check 'hdiutil-attach
-                    "hdiutil" "attach"
+                    "/usr/bin/hdiutil" "attach"
                     "-nobrowse" "-noverify" "-noautoopen"
                     "-mountpoint" (path->string* mount-point)
                     (path->string* dmg)))
@@ -222,7 +222,7 @@
          [else mount-point]))
      (copy-directory/files src-dir dest #:keep-modify-seconds? #t))
    (lambda ()
-     (system* "hdiutil" "detach" (path->string* mount-point) "-quiet")
+     (system* "/usr/bin/hdiutil" "detach" (path->string* mount-point) "-quiet")
      (when (directory-exists? mount-point)
        (delete-directory mount-point)))))
 

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -204,7 +204,6 @@
                     "-mountpoint" (path->string* mount-point)
                     (path->string* dmg)))
    (lambda ()
-     (make-directory* dest)
      ;; Racket .dmg files contain a top-level directory like "Racket v9.1/"
      ;; with the standard bin/, lib/, share/ layout inside.
      (define top-dirs

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -22,7 +22,8 @@
          link-toolchain!
          remove-toolchain!
          run-linux-installer!
-         run-linux-tgz-installer!
+         run-tgz-installer!
+         run-macos-dmg-installer!
          enumerate-toolchain-executables
          doctor-report)
 
@@ -173,7 +174,7 @@
     (unless (string-blank? details)
       (eprintf "~a\n" (truncate-lines details)))
     (delete-log!)
-    (rackup-error "linux-installer failed: ~a (~a)"
+    (rackup-error "installer failed: ~a (~a)"
                   (path->string* installer)
                   (if legacy-kind
                       "legacy interactive mode"
@@ -183,18 +184,54 @@
 (define (tar-exe)
   (or (find-executable-path "tar") (string->path "/bin/tar")))
 
-(define (run-linux-tgz-installer! installer-file install-root)
+(define (run-tgz-installer! installer-file install-root)
   (define archive (path->complete-path installer-file))
   (define dest (path->complete-path install-root))
   (install-verbose "Extracting archive into ~a" (path->string dest))
   (make-directory* dest)
   (system*/check 'linux-tgz-installer (tar-exe) "-xzf" archive "-C" dest))
 
+(define (run-macos-dmg-installer! installer-file install-root)
+  (define dmg (path->complete-path installer-file))
+  (define dest (path->complete-path install-root))
+  (define mount-point (make-temporary-file "rackup-dmg-~a" 'directory))
+  (install-verbose "Mounting DMG and extracting into ~a" (path->string dest))
+  (dynamic-wind
+   (lambda ()
+     (system*/check 'hdiutil-attach
+                    "hdiutil" "attach"
+                    "-nobrowse" "-noverify" "-noautoopen"
+                    "-mountpoint" (path->string* mount-point)
+                    (path->string* dmg)))
+   (lambda ()
+     (make-directory* dest)
+     ;; Racket .dmg files contain a top-level directory like "Racket v9.1/"
+     ;; with the standard bin/, lib/, share/ layout inside.
+     (define top-dirs
+       (for/list ([p (directory-list mount-point #:build? #t)]
+                  #:when (directory-exists? p))
+         p))
+     (define src-dir
+       (cond
+         [(and (= (length top-dirs) 1)
+               (directory-exists? (build-path (car top-dirs) "bin")))
+          (car top-dirs)]
+         [(directory-exists? (build-path mount-point "bin"))
+          mount-point]
+         [(pair? top-dirs) (car top-dirs)]
+         [else mount-point]))
+     (copy-directory/files src-dir dest #:keep-modify-seconds? #t))
+   (lambda ()
+     (system* "hdiutil" "detach" (path->string* mount-point) "-quiet")
+     (when (directory-exists? mount-point)
+       (delete-directory mount-point)))))
+
 (define (installer-filename-extension s)
   (define low (string-downcase s))
   (cond
     [(regexp-match? #px"[.]sh$" low) "sh"]
     [(regexp-match? #px"[.]tgz$" low) "tgz"]
+    [(regexp-match? #px"[.]dmg$" low) "dmg"]
     [else #f]))
 
 (define (detect-bin-dir install-root)
@@ -611,6 +648,7 @@
   (define force? #f)
   (define no-cache? #f)
   (define verbosity 'normal)
+  (define installer-ext #f)
   (command-line #:program "rackup install"
                 #:argv opts
                 #:once-each [("--variant") v "VM variant" (set! variant v)]
@@ -620,6 +658,7 @@
                 [("--set-default") "Set installed toolchain as default" (set! set-default? #t)]
                 [("--force") "Reinstall existing canonical toolchain" (set! force? #t)]
                 [("--no-cache") "Redownload installer instead of using cache" (set! no-cache? #t)]
+                [("--installer-ext") e "Force installer extension (sh, tgz, dmg)" (set! installer-ext e)]
                 #:once-any
                 [("--quiet") "Show minimal install output" (set! verbosity 'quiet)]
                 [("--verbose") "Show detailed installer URL/path output" (set! verbosity 'verbose)]
@@ -640,7 +679,9 @@
         'no-cache?
         no-cache?
         'verbosity
-        verbosity))
+        verbosity
+        'installer-ext
+        installer-ext))
 
 (define (parse-link-options opts)
   (define set-default? #f)
@@ -660,11 +701,7 @@
   (string-append "local-" (sanitize-id-part name)))
 
 (define (local-toolchain-meta id name layout real-bin-dir executables env-vars version* variant*)
-  (define platform-raw (system-type 'os))
-  (define platform
-    (if (symbol? platform-raw)
-        (symbol->string platform-raw)
-        (format "~a" platform-raw)))
+  (define platform (host-platform-token))
   (hash 'id
         id
         'kind
@@ -789,7 +826,8 @@
                              #:variant (hash-ref parsed-opts 'variant)
                              #:distribution (hash-ref parsed-opts 'distribution)
                              #:arch (hash-ref parsed-opts 'arch)
-                             #:snapshot-site (hash-ref parsed-opts 'snapshot-site)))
+                             #:snapshot-site (hash-ref parsed-opts 'snapshot-site)
+                             #:installer-ext (hash-ref parsed-opts 'installer-ext #f)))
   (define id (canonical-id-for-request request))
   (define tc-dir (rackup-toolchain-dir id))
   (define install-root (rackup-toolchain-install-dir id))
@@ -830,9 +868,11 @@
             (run-linux-installer! installer-path
                                   install-root
                                   #:legacy-install-kind (hash-ref request 'legacy-install-kind #f))]
-           [(equal? installer-ext "tgz") (run-linux-tgz-installer! installer-path install-root)]
+           [(equal? installer-ext "tgz") (run-tgz-installer! installer-path install-root)]
+           [(equal? installer-ext "dmg") (run-macos-dmg-installer! installer-path install-root)]
            [else
-            (rackup-error "unsupported installer format for Linux: ~a"
+            (rackup-error "unsupported installer format for ~a: ~a"
+                          (host-platform-token)
                           (or installer-ext "unknown"))])
          (define real-bin-dir (detect-bin-dir install-root))
          (maybe-modernize-legacy-archsys! real-bin-dir)

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -204,20 +204,22 @@
                     "-mountpoint" (path->string* mount-point)
                     (path->string* dmg)))
    (lambda ()
-     ;; Racket .dmg files contain a top-level directory like "Racket v9.1/"
-     ;; with the standard bin/, lib/, share/ layout inside.
+     ;; Racket .dmg files are drag-and-drop installers containing:
+     ;; - A directory like "Racket v9.1/" with bin/, lib/, share/ inside
+     ;; - A symlink to /Applications (for drag-and-drop UX)
+     ;; We must skip symlinks to avoid copying the system /Applications.
      (define top-dirs
        (for/list ([p (directory-list mount-point #:build? #t)]
-                  #:when (directory-exists? p))
+                  #:when (and (directory-exists? p)
+                              (not (link-exists? p))))
          p))
      (define src-dir
        (cond
-         [(and (= (length top-dirs) 1)
-               (directory-exists? (build-path (car top-dirs) "bin")))
-          (car top-dirs)]
+         [(for/or ([d (in-list top-dirs)])
+            (and (directory-exists? (build-path d "bin")) d))]
          [(directory-exists? (build-path mount-point "bin"))
           mount-point]
-         [(pair? top-dirs) (car top-dirs)]
+         [(= (length top-dirs) 1) (car top-dirs)]
          [else mount-point]))
      (copy-directory/files src-dir dest #:keep-modify-seconds? #t))
    (lambda ()

--- a/libexec/rackup/legacy-plt-catalog.rkt
+++ b/libexec/rackup/legacy-plt-catalog.rkt
@@ -111,30 +111,35 @@
            'artifacts
            (list
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-350-bin-i386-linux.sh" 'url "http://download.plt-scheme.org/bundles/350/plt/plt-350-bin-i386-linux.sh" 'sha256 "3165ae053db8fc03fbb465b39e6d782b888aa5bd9a86b904606a3277674bc77e" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-350-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/350/plt/plt-350-bin-i386-osx-mac.dmg" 'sha256 "cdd87f4aec736bdfb210539ffe267737d837896d5900aa1d1e745a94baea7502" )
             ))
    "351"
    (hasheq 'install-kind 'shell-unixstyle
            'artifacts
            (list
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-351-bin-i386-linux.sh" 'url "http://download.plt-scheme.org/bundles/351/plt/plt-351-bin-i386-linux.sh" 'sha256 "0e7a273d162dae7cef7626b134b73f04e8428c84252f64fdff81321cf47e154c" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-351-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/351/plt/plt-351-bin-i386-osx-mac.dmg" 'sha256 "eb57d2991598dc41bf736b9c4f2e97155bb39aece7675fc8c3183520ad7a9733" )
             ))
    "352"
    (hasheq 'install-kind 'shell-unixstyle
            'artifacts
            (list
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-352-bin-i386-linux.sh" 'url "http://download.plt-scheme.org/bundles/352/plt/plt-352-bin-i386-linux.sh" 'sha256 "2881012a55f797dc54dd2c001516dd6ce97cb4344b25293cb0802ea0f855adba" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-352-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/352/plt/plt-352-bin-i386-osx-mac.dmg" 'sha256 "16ea5c1fef79a219dc534f67a1e22158751d55b08b4bf746923708adcc1e6295" )
             ))
    "360"
    (hasheq 'install-kind 'shell-unixstyle
            'artifacts
            (list
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-360-bin-i386-linux-fc2.sh" 'url "http://download.plt-scheme.org/bundles/360/plt/plt-360-bin-i386-linux-fc2.sh" 'sha256 "4348129d674dbdf1a88a4519dfa9fea21c669c33a5343561ec1da9775e4de8a0" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-360-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/360/plt/plt-360-bin-i386-osx-mac.dmg" 'sha256 "0157daec43bd8d824b4f54e7267717e81ae3f7d2906213d61cad36fa731505f6" )
             ))
    "370"
    (hasheq 'install-kind 'shell-unixstyle
            'artifacts
            (list
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-370-bin-i386-linux-fc6.sh" 'url "http://download.plt-scheme.org/bundles/370/plt/plt-370-bin-i386-linux-fc6.sh" 'sha256 "59423400a36d18b3dc82acdfeb82675d02b55d9d6aad068103c4255a9bd1b26d" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-370-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/370/plt/plt-370-bin-i386-osx-mac.dmg" 'sha256 "8fa1df0339265b9242ef2a006c86d36396d85d03c507fe36a4cdb6e10ba1d0f6" )
             ))
    "371"
    (hasheq 'install-kind 'shell-unixstyle
@@ -142,6 +147,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-371-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/371/plt/plt-371-bin-x86_64-linux-f7.sh" 'sha256 "43eb27434406fc6846369e994ce5c6b0ebd8b7debd3dad5f2574da622b29ed01" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-371-bin-i386-linux-fc6.sh" 'url "http://download.plt-scheme.org/bundles/371/plt/plt-371-bin-i386-linux-fc6.sh" 'sha256 "6413e84e2e24e018ccbac1c44e1a464daf612465f815a62fc37ecbcdcf49b6b3" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-371-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/371/plt/plt-371-bin-i386-osx-mac.dmg" 'sha256 "3d6b56a63c26b3025924555b9d3dbb446ae8f4aa122203beef6287ef7d93c460" )
             ))
    "372"
    (hasheq 'install-kind 'shell-unixstyle
@@ -149,6 +155,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-372-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/372/plt/plt-372-bin-x86_64-linux-f7.sh" 'sha256 "e1fbd756964aad7236d07cfff752075249cb7e9761cbf23de557beae904eecbb" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-372-bin-i386-linux-fc6.sh" 'url "http://download.plt-scheme.org/bundles/372/plt/plt-372-bin-i386-linux-fc6.sh" 'sha256 "4fd2c4277e0a7e503caa1eb30a28b2245ac14ba8b442fbf88cb929436f8b331a" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-372-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/372/plt/plt-372-bin-i386-osx-mac.dmg" 'sha256 "fbbf472db621359defdc8b61713fbb60682c483a14e33d6ce336c8354df6bee1" )
             ))
    "4.0"
    (hasheq 'install-kind 'shell-unixstyle
@@ -156,6 +163,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.0-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.0/plt/plt-4.0-bin-x86_64-linux-f7.sh" 'sha256 "0c9de49ea4b22290e8bae531ee6ed6f6763b4b7b17b9df171ee9f19af183c9e1" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.0-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.0/plt/plt-4.0-bin-i386-linux-f9.sh" 'sha256 "2b74b627be600f08712a309760aeda242b5933745fefe3bcb6b509f31c9adc09" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.0-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.0/plt/plt-4.0-bin-i386-osx-mac.dmg" 'sha256 "17b6b27b937c30a10464275beb1c170b5b7248b081fe8d13f68558aedbcadacd" )
             ))
    "4.0.1"
    (hasheq 'install-kind 'shell-unixstyle
@@ -163,6 +171,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.0.1-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.0.1/plt/plt-4.0.1-bin-x86_64-linux-f7.sh" 'sha256 "aeadf35f828cdf88a1724b42b7486c507fee8471a990f1079271948179e60f69" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.0.1-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.0.1/plt/plt-4.0.1-bin-i386-linux-f9.sh" 'sha256 "806599ccc21b1708c78f45c41978e2ccb0f128d78e8422f4e382fb86a8468d71" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.0.1-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.0.1/plt/plt-4.0.1-bin-i386-osx-mac.dmg" 'sha256 "1a084609fe4197b5eaea2137d86d57a250aa294a80e02509309434705d710127" )
             ))
    "4.0.2"
    (hasheq 'install-kind 'shell-unixstyle
@@ -170,6 +179,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.0.2-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.0.2/plt/plt-4.0.2-bin-x86_64-linux-f7.sh" 'sha256 "3c9856f06be1dadf1b64fce99951ce0a5f870d0da6ffe3098b79c794ef6726a9" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.0.2-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.0.2/plt/plt-4.0.2-bin-i386-linux-f9.sh" 'sha256 "deb27f6224423ed7d864b3d449526d0187dda607a15fe361cdc1cfbdb7d43e4a" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.0.2-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.0.2/plt/plt-4.0.2-bin-i386-osx-mac.dmg" 'sha256 "1556215a99c81202210c21d138188befb64304ee7e2947ecd1b64f8dbdf8f2ba" )
             ))
    "4.1"
    (hasheq 'install-kind 'shell-unixstyle
@@ -177,6 +187,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.1-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.1/plt/plt-4.1-bin-x86_64-linux-f7.sh" 'sha256 "2d2caa93a8e84e1a883acd5534cdf63bb5589df694f487159e0941a8667be78e" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.1-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.1/plt/plt-4.1-bin-i386-linux-f9.sh" 'sha256 "35f2879b0f3722ee46647bb5b67593c08ca12f471514ad26e1dc9b77953414d8" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.1-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.1/plt/plt-4.1-bin-i386-osx-mac.dmg" 'sha256 "441a0b5ee58bd9295de704b7d112f386f8e51acbe41a26975040da659bd21d37" )
             ))
    "4.1.1"
    (hasheq 'install-kind 'shell-unixstyle
@@ -184,6 +195,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.1.1-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.1.1/plt/plt-4.1.1-bin-x86_64-linux-f7.sh" 'sha256 "0daf245391d648db72d2312717c795c0cdc52228764a9213fa4cbda3229d91e9" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.1.1-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.1.1/plt/plt-4.1.1-bin-i386-linux-f9.sh" 'sha256 "b147467b75210a6262beb5e23c2e2d881a264dd71b6fc1444034242ae56a82c6" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.1.1-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.1.1/plt/plt-4.1.1-bin-i386-osx-mac.dmg" 'sha256 "fe469a0d6658b936796d0d050e948e2eaec712f9a03923239705a43f82963f6d" )
             ))
    "4.1.2"
    (hasheq 'install-kind 'shell-unixstyle
@@ -191,6 +203,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.1.2-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.1.2/plt/plt-4.1.2-bin-x86_64-linux-f7.sh" 'sha256 "757246b67cbd2bfaf5e076a1691db501417125fd5eeed8c24a13885ddc943dff" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.1.2-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.1.2/plt/plt-4.1.2-bin-i386-linux-f9.sh" 'sha256 "876b2a18c55e4ee76f264002871309410f333cf3c0f316a9c79fbe8b07528262" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.1.2-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.1.2/plt/plt-4.1.2-bin-i386-osx-mac.dmg" 'sha256 "6f29a357cd3a3556142b09c1d1250871a87e4f7dba3d0bc397b475395829271b" )
             ))
    "4.1.3"
    (hasheq 'install-kind 'shell-unixstyle
@@ -198,6 +211,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.1.3-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.1.3/plt/plt-4.1.3-bin-x86_64-linux-f7.sh" 'sha256 "66e57fe9dc610a923505e3d317edc321fccfc4209ca66c98268706bef934f30d" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.1.3-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.1.3/plt/plt-4.1.3-bin-i386-linux-f9.sh" 'sha256 "73c035d34142382bcfa1082b9a8efe98169d0959a8db351e6e1e299de119c45e" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.1.3-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.1.3/plt/plt-4.1.3-bin-i386-osx-mac.dmg" 'sha256 "cb5c31110daeaf1cfb7dc051a16646b940b89a2d1738677a580af24ba71c8bbd" )
             ))
    "4.1.4"
    (hasheq 'install-kind 'shell-unixstyle
@@ -205,6 +219,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.1.4-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.1.4/plt/plt-4.1.4-bin-x86_64-linux-f7.sh" 'sha256 "bbcac181b0ec2948877108d92fc7fb6e2f3965c134d08bfb01b9f052d18a13d0" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.1.4-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.1.4/plt/plt-4.1.4-bin-i386-linux-f9.sh" 'sha256 "897918debca65492545d67075de0a0bee846b98a9f6c7bc6c226890b8249c998" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.1.4-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.1.4/plt/plt-4.1.4-bin-i386-osx-mac.dmg" 'sha256 "892003a8295878d5b313dd72d81c5abd441f8591729e89a80db077449779b07d" )
             ))
    "4.1.5"
    (hasheq 'install-kind 'shell-unixstyle
@@ -212,6 +227,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.1.5-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.1.5/plt/plt-4.1.5-bin-x86_64-linux-f7.sh" 'sha256 "fe3a0d677efa563dab170724782f0ce7ca93c439edb77c9ecc68df64ef769de4" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.1.5-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.1.5/plt/plt-4.1.5-bin-i386-linux-f9.sh" 'sha256 "7d8911480517bcbdca0ed399bcd9c79787560b6739a034a3f8974baf176247d5" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.1.5-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.1.5/plt/plt-4.1.5-bin-i386-osx-mac.dmg" 'sha256 "e3aa2c83ad5e09be1aa876904bcfff16e2cd35f8f2dfca0d8d1d0102bb27012a" )
             ))
    "4.2"
    (hasheq 'install-kind 'shell-unixstyle
@@ -219,6 +235,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.2-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.2/plt/plt-4.2-bin-x86_64-linux-f7.sh" 'sha256 "fed7ff042276778ab5fca99cf6c235f98de497340d78fd8a2aa8d20a98f43a43" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.2-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.2/plt/plt-4.2-bin-i386-linux-f9.sh" 'sha256 "f3912f9146b8ebf2c3a7508a6fc41b6666d3580bfc80597c5b78577cd4032521" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.2-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.2/plt/plt-4.2-bin-i386-osx-mac.dmg" 'sha256 "428bbb09749f05b44d3a7743c57dbee9dee48e2641958d5a4869353a8f9f065c" )
             ))
    "4.2.1"
    (hasheq 'install-kind 'shell-unixstyle
@@ -226,6 +243,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.2.1-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.2.1/plt/plt-4.2.1-bin-x86_64-linux-f7.sh" 'sha256 "52de054982e1fad063adae041c7104fd4042528f5a6279222cae8bd29423620f" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.2.1-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.2.1/plt/plt-4.2.1-bin-i386-linux-f9.sh" 'sha256 "698d990713ab928a1751d057fe4ba0c16f3ade95602968cabdb9c67f611b89fe" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.2.1-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.2.1/plt/plt-4.2.1-bin-i386-osx-mac.dmg" 'sha256 "915a34e36f6f18325aca3bd917381deacfdb7fc6686bf22d62b836c71dc050a1" )
             ))
    "4.2.2"
    (hasheq 'install-kind 'shell-unixstyle
@@ -233,6 +251,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.2.2-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.2.2/plt/plt-4.2.2-bin-x86_64-linux-f7.sh" 'sha256 "c453e9873bf4ce16a2ddb8c8f926d38f8f378e7627a4f522e9a0c91c7739b75d" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.2.2-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.2.2/plt/plt-4.2.2-bin-i386-linux-f9.sh" 'sha256 "2ec1672036f20b40cfba929240babbd61efd16f39b5afc9132b705ea7942f761" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.2.2-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.2.2/plt/plt-4.2.2-bin-i386-osx-mac.dmg" 'sha256 "84a8fa69b2c896d00a6464655c0d65c3922cd77a1ccd047bfd8cecaca0e2365e" )
             ))
    "4.2.3"
    (hasheq 'install-kind 'shell-unixstyle
@@ -240,6 +259,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.2.3-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.2.3/plt/plt-4.2.3-bin-x86_64-linux-f7.sh" 'sha256 "7b14b1a4935c389b5236358b9a4c70f58a266f4ec9d0d4f7de0de877d7c08db4" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.2.3-bin-i386-linux-f9.sh" 'url "http://download.plt-scheme.org/bundles/4.2.3/plt/plt-4.2.3-bin-i386-linux-f9.sh" 'sha256 "53c9dc6a6e11dd5753f005c23d18f1301dd1baf7ac424afc587cddc338be58bc" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.2.3-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.2.3/plt/plt-4.2.3-bin-i386-osx-mac.dmg" 'sha256 "245fbb66e1f977e66db9d40b353b8bcdba9e09699ec5aeef21122b2bbcde0561" )
             ))
    "4.2.4"
    (hasheq 'install-kind 'shell-unixstyle
@@ -247,6 +267,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.2.4-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.2.4/plt/plt-4.2.4-bin-x86_64-linux-f7.sh" 'sha256 "fd0a63a18fe6bc57320d85c6c2b558b14cc26ed6b721968339c4c81a96be54ed" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.2.4-bin-i386-linux-f12.sh" 'url "http://download.plt-scheme.org/bundles/4.2.4/plt/plt-4.2.4-bin-i386-linux-f12.sh" 'sha256 "37dfb77c07406de77f730d25ba0312337a7d29b73d00678b87dcb4826700cbf1" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.2.4-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.2.4/plt/plt-4.2.4-bin-i386-osx-mac.dmg" 'sha256 "2cf39ec0f12279adabc07e272f0ea9309a38772a8d0fb36f71fa6bb60018f381" )
             ))
    "4.2.5"
    (hasheq 'install-kind 'shell-unixstyle
@@ -254,6 +275,7 @@
            (list
             (hasheq 'arch "x86_64" 'platform "linux" 'ext "sh" 'filename "plt-4.2.5-bin-x86_64-linux-f7.sh" 'url "http://download.plt-scheme.org/bundles/4.2.5/plt/plt-4.2.5-bin-x86_64-linux-f7.sh" 'sha256 "a9e75aaebf4eb6d74f24787f0621367b2123ec3f8f37019264cad9510e732edb" )
             (hasheq 'arch "i386" 'platform "linux" 'ext "sh" 'filename "plt-4.2.5-bin-i386-linux-f12.sh" 'url "http://download.plt-scheme.org/bundles/4.2.5/plt/plt-4.2.5-bin-i386-linux-f12.sh" 'sha256 "71cf7b465e3edceb82495cd5adb17c438c988b15024986f7bf9a269ec15239a0" )
+            (hasheq 'arch "i386" 'platform "macosx" 'ext "dmg" 'install-kind 'dmg 'filename "plt-4.2.5-bin-i386-osx-mac.dmg" 'url "http://download.plt-scheme.org/bundles/4.2.5/plt/plt-4.2.5-bin-i386-osx-mac.dmg" 'sha256 "8d1877303704ae2af6df51848f3922b04a55a28f43e353d465fbf1332bc84cbd" )
             ))
    ))
 
@@ -275,12 +297,12 @@
                                  #:platform [platform "linux"])
   (unless (eq? distribution 'full)
     (rackup-error "PLT Scheme releases (~a) do not support --distribution ~a" version distribution))
-  (unless (equal? platform "linux")
+  (unless (member platform '("linux" "macosx"))
     (rackup-error "PLT Scheme releases (~a) do not support platform ~a" version platform))
   (define release (hash-ref legacy-plt-release-info version #f))
   (unless release
     (rackup-error
-     "PLT Scheme version ~a is in the historical release range, but rackup does not have a hardcoded Linux installer entry for it."
+     "PLT Scheme version ~a is in the historical release range, but rackup does not have a hardcoded installer entry for it."
      version))
   (define reason (hash-ref release 'reason #f))
   (when reason
@@ -294,7 +316,9 @@
   (cond
     [(pair? matches)
      (define artifact (car matches))
-     (hash-set artifact 'install-kind (hash-ref release 'install-kind))]
+     ;; Per-artifact install-kind overrides the release-level default (for macOS DMGs).
+     (hash-set artifact 'install-kind
+               (hash-ref artifact 'install-kind (hash-ref release 'install-kind)))]
     [else
      (define supported-arches
        (remove-duplicates
@@ -302,12 +326,22 @@
                    #:when (equal? (hash-ref artifact 'platform) platform))
           (hash-ref artifact 'arch))
         string=?))
+     (define supported-platforms
+       (remove-duplicates
+        (for/list ([artifact (in-list artifacts)])
+          (hash-ref artifact 'platform))
+        string=?))
      (define hint
        (cond
+         [(and (equal? platform "macosx") (not (member "macosx" supported-platforms)))
+          " (this PLT Scheme version does not have macOS installers in rackup's catalog)"]
          [(and (equal? arch "x86_64") (member "i386" supported-arches))
-          " (this PLT Scheme version appears to have only i386 Linux installers; try --arch i386)"]
+          (format " (this PLT Scheme version has only i386 ~a installers; try --arch i386)"
+                  (if (equal? platform "macosx") "macOS" "Linux"))]
          [(pair? supported-arches)
-          (format " (supported Linux arch values: ~a)" (string-join supported-arches ", "))]
+          (format " (supported ~a arch values: ~a)"
+                  (if (equal? platform "macosx") "macOS" "Linux")
+                  (string-join supported-arches ", "))]
          [else ""]))
      (rackup-error "no PLT Scheme installer found for version=~a arch=~a platform=~a~a"
                    version

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -114,6 +114,8 @@
      (help-option-line "--set-default" "Set installed toolchain as the global default.")
      (help-option-line "--force" "Reinstall if the same canonical toolchain is already installed.")
      (help-option-line "--no-cache" "Redownload installer instead of using cache.")
+     (help-option-line "--installer-ext sh|tgz|dmg"
+                       "Force installer extension (default: platform-dependent).")
      (help-option-line "--quiet" "Show minimal output (errors + final result lines).")
      (help-option-line "--verbose" "Show detailed installer URL/path output.")
      (displayln "")
@@ -316,7 +318,9 @@
         "--quiet"
         0
         "--verbose"
-        0))
+        0
+        "--installer-ext"
+        1))
 
 (define (string-flag-like? s)
   (and (string? s) (> (string-length s) 0) (char=? (string-ref s 0) #\-)))

--- a/libexec/rackup/remote.rkt
+++ b/libexec/rackup/remote.rkt
@@ -25,6 +25,7 @@
          parse-legacy-installers-index-html
          parse-plt-version-page-html
          select-installer-filename
+         select-installer-filename/by-ext
          select-legacy-installer-filename
          select-plt-generated-page-url
          plt-generated-page-url->installer-filename
@@ -372,7 +373,7 @@
                                          #:distribution distribution*
                                          #:arch arch
                                          #:platform platform
-                                         #:exts '("sh" "tgz")
+                                         #:exts preferred-exts
                                          #:allow-version-prefix? #t))
      (release-request-hash requested-spec
                            resolved-version
@@ -576,7 +577,8 @@
                                  #:variant [variant-override #f]
                                  #:distribution [distribution 'full]
                                  #:arch [arch (normalized-host-arch)]
-                                 #:snapshot-site [snapshot-site-opt 'auto])
+                                 #:snapshot-site [snapshot-site-opt 'auto]
+                                 #:installer-ext [installer-ext-override #f])
   (define spec*
     (if (string? spec)
         (parse-install-spec spec)
@@ -584,7 +586,14 @@
   (define kind (hash-ref spec* 'kind))
   (define distribution* (parse-distribution distribution))
   (define requested-spec (hash-ref spec* 'input ""))
-  (define platform "linux")
+  (define platform (host-platform-token))
+  (define preferred-exts
+    (if installer-ext-override
+        (list installer-ext-override)
+        (match platform
+          ["macosx"  '("tgz" "dmg")]
+          ["linux"   '("sh" "tgz")]
+          [_ (rackup-error "no installer extension preferences for platform: ~a" platform)])))
   (define (variant-for version)
     (define legacy-plt? (version-maybe-plt-scheme? version))
     (define v
@@ -638,7 +647,7 @@
                                          #:distribution distribution*
                                          #:arch arch
                                          #:platform platform
-                                         #:exts '("sh" "tgz")
+                                         #:exts preferred-exts
                                          #:allow-version-prefix? allow-prefix?))
      (define filename
        (with-handlers ([exn:fail? (lambda (e)
@@ -704,7 +713,7 @@
                                            #:distribution distribution*
                                            #:arch arch
                                            #:platform platform
-                                           #:exts '("sh" "tgz")))
+                                           #:exts preferred-exts))
      (hash 'kind
            'snapshot
            'requested-spec

--- a/libexec/rackup/remote.rkt
+++ b/libexec/rackup/remote.rkt
@@ -332,7 +332,8 @@
                                           variant
                                           distribution*
                                           arch
-                                          platform)
+                                          platform
+                                          preferred-exts)
   (cond
     [(version-maybe-plt-scheme? resolved-version)
      (define plt-request
@@ -616,7 +617,8 @@
                                        variant
                                        distribution*
                                        arch
-                                       platform)]
+                                       platform
+                                       preferred-exts)]
     ['release
      (define resolved-version (hash-ref spec* 'version))
      (define variant (variant-for resolved-version))
@@ -625,7 +627,8 @@
                                        variant
                                        distribution*
                                        arch
-                                       platform)]
+                                       platform
+                                       preferred-exts)]
     ['pre-release
      (define table (fetch-table-rktd pre-release-installers-base))
      ;; pre-release.racket-lang.org may not publish installers/version.rktd.

--- a/libexec/rackup/remote.rkt
+++ b/libexec/rackup/remote.rkt
@@ -578,6 +578,7 @@
                                  #:variant [variant-override #f]
                                  #:distribution [distribution 'full]
                                  #:arch [arch (normalized-host-arch)]
+                                 #:platform [platform-override #f]
                                  #:snapshot-site [snapshot-site-opt 'auto]
                                  #:installer-ext [installer-ext-override #f])
   (define spec*
@@ -587,7 +588,7 @@
   (define kind (hash-ref spec* 'kind))
   (define distribution* (parse-distribution distribution))
   (define requested-spec (hash-ref spec* 'input ""))
-  (define platform (host-platform-token))
+  (define platform (or platform-override (host-platform-token)))
   (define preferred-exts
     (if installer-ext-override
         (list installer-ext-override)

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -108,7 +108,6 @@
                     "-mountpoint" (path->string* mount-point)
                     (path->string* dmg)))
    (lambda ()
-     (make-directory* dest)
      ;; Racket .dmg files contain a top-level directory like "Racket v9.1/"
      ;; with the standard bin/, lib/, share/ layout inside.
      (define top-dirs

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -88,18 +88,54 @@
 (define (tar-exe)
   (or (find-executable-path "tar") (string->path "/bin/tar")))
 
-(define (run-linux-tgz-installer! installer-file install-root)
+(define (run-tgz-installer! installer-file install-root)
   (define archive (path->complete-path installer-file))
   (define dest (path->complete-path install-root))
   (displayln (format "Extracting hidden runtime archive into ~a" (path->string dest)))
   (make-directory* dest)
   (system*/check 'hidden-runtime-tgz-installer (tar-exe) "-xzf" archive "-C" dest))
 
+(define (run-macos-dmg-installer! installer-file install-root)
+  (define dmg (path->complete-path installer-file))
+  (define dest (path->complete-path install-root))
+  (define mount-point (make-temporary-file "rackup-dmg-~a" 'directory))
+  (displayln (format "Mounting DMG and extracting hidden runtime into ~a" (path->string dest)))
+  (dynamic-wind
+   (lambda ()
+     (system*/check 'hdiutil-attach
+                    "hdiutil" "attach"
+                    "-nobrowse" "-noverify" "-noautoopen"
+                    "-mountpoint" (path->string* mount-point)
+                    (path->string* dmg)))
+   (lambda ()
+     (make-directory* dest)
+     ;; Racket .dmg files contain a top-level directory like "Racket v9.1/"
+     ;; with the standard bin/, lib/, share/ layout inside.
+     (define top-dirs
+       (for/list ([p (directory-list mount-point #:build? #t)]
+                  #:when (directory-exists? p))
+         p))
+     (define src-dir
+       (cond
+         [(and (= (length top-dirs) 1)
+               (directory-exists? (build-path (car top-dirs) "bin")))
+          (car top-dirs)]
+         [(directory-exists? (build-path mount-point "bin"))
+          mount-point]
+         [(pair? top-dirs) (car top-dirs)]
+         [else mount-point]))
+     (copy-directory/files src-dir dest #:keep-modify-seconds? #t))
+   (lambda ()
+     (system* "hdiutil" "detach" (path->string* mount-point) "-quiet")
+     (when (directory-exists? mount-point)
+       (delete-directory mount-point)))))
+
 (define (installer-extension p)
   (define low (string-downcase (path->string* p)))
   (cond
     [(regexp-match? #px"[.]sh$" low) "sh"]
     [(regexp-match? #px"[.]tgz$" low) "tgz"]
+    [(regexp-match? #px"[.]dmg$" low) "dmg"]
     [else #f]))
 
 (define (detect-bin-dir install-root)
@@ -205,7 +241,7 @@
                 'arch
                 (normalized-host-arch)
                 'platform
-                "linux"))
+                (host-platform-token)))
         (define real-bin
           (with-handlers ([exn:fail? (lambda (_) (build-path (rackup-runtime-current-link) "bin"))])
             (resolve-path (build-path (rackup-runtime-current-link) "bin"))))
@@ -320,7 +356,9 @@
                       [(equal? installer-ext "sh")
                        (run-linux-installer! installer-file install-root)]
                       [(equal? installer-ext "tgz")
-                       (run-linux-tgz-installer! installer-file install-root)]
+                       (run-tgz-installer! installer-file install-root)]
+                      [(equal? installer-ext "dmg")
+                       (run-macos-dmg-installer! installer-file install-root)]
                       [else
                        (rackup-error "unsupported hidden runtime installer format: ~a"
                                      (or installer-ext "unknown"))])

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -108,20 +108,22 @@
                     "-mountpoint" (path->string* mount-point)
                     (path->string* dmg)))
    (lambda ()
-     ;; Racket .dmg files contain a top-level directory like "Racket v9.1/"
-     ;; with the standard bin/, lib/, share/ layout inside.
+     ;; Racket .dmg files are drag-and-drop installers containing:
+     ;; - A directory like "Racket v9.1/" with bin/, lib/, share/ inside
+     ;; - A symlink to /Applications (for drag-and-drop UX)
+     ;; We must skip symlinks to avoid copying the system /Applications.
      (define top-dirs
        (for/list ([p (directory-list mount-point #:build? #t)]
-                  #:when (directory-exists? p))
+                  #:when (and (directory-exists? p)
+                              (not (link-exists? p))))
          p))
      (define src-dir
        (cond
-         [(and (= (length top-dirs) 1)
-               (directory-exists? (build-path (car top-dirs) "bin")))
-          (car top-dirs)]
+         [(for/or ([d (in-list top-dirs)])
+            (and (directory-exists? (build-path d "bin")) d))]
          [(directory-exists? (build-path mount-point "bin"))
           mount-point]
-         [(pair? top-dirs) (car top-dirs)]
+         [(= (length top-dirs) 1) (car top-dirs)]
          [else mount-point]))
      (copy-directory/files src-dir dest #:keep-modify-seconds? #t))
    (lambda ()

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -103,7 +103,7 @@
   (dynamic-wind
    (lambda ()
      (system*/check 'hdiutil-attach
-                    "hdiutil" "attach"
+                    "/usr/bin/hdiutil" "attach"
                     "-nobrowse" "-noverify" "-noautoopen"
                     "-mountpoint" (path->string* mount-point)
                     (path->string* dmg)))
@@ -126,7 +126,7 @@
          [else mount-point]))
      (copy-directory/files src-dir dest #:keep-modify-seconds? #t))
    (lambda ()
-     (system* "hdiutil" "detach" (path->string* mount-point) "-quiet")
+     (system* "/usr/bin/hdiutil" "detach" (path->string* mount-point) "-quiet")
      (when (directory-exists? mount-point)
        (delete-directory mount-point)))))
 

--- a/libexec/rackup/versioning.rkt
+++ b/libexec/rackup/versioning.rkt
@@ -15,7 +15,7 @@
          canonical-toolchain-id
          sanitize-id-part
          normalized-host-arch
-         linux-platform-token
+         host-platform-token
          arch-token->normalized
          variant->string
          distribution->string)
@@ -143,8 +143,14 @@
     [(regexp-match? #px"ppc|powerpc" m) "ppc"]
     [else m*]))
 
-(define (linux-platform-token)
-  "linux")
+;; Returns the platform token for the current host OS.
+;; TODO: BSD also reports 'unix via (system-type 'os) — if BSD support is added,
+;; use (system-type) or uname to distinguish Linux from FreeBSD/OpenBSD/etc.
+(define (host-platform-token)
+  (case (system-type 'os)
+    [(macosx) "macosx"]
+    [(unix)   "linux"]
+    [else (rackup-error "unsupported platform: ~a" (system-type 'os))]))
 
 (define (arch-token->normalized token)
   (cond

--- a/test/remote.rkt
+++ b/test/remote.rkt
@@ -288,6 +288,29 @@
                 "http://download.plt-scheme.org/bundles/4.2.5/plt/plt-4.2.5-bin-x86_64-linux-f7.sh")
   (check-equal? (hash-ref legacy-req-4.2.5 'legacy-install-kind) 'shell-unixstyle)
 
+  ;; macOS DMG installers for legacy PLT Scheme versions
+  (define legacy-req-4.2.5-mac (resolve-install-request/runtime "4.2.5" #:arch "i386" #:platform "macosx"))
+  (check-equal? (hash-ref legacy-req-4.2.5-mac 'installer-url)
+                "http://download.plt-scheme.org/bundles/4.2.5/plt/plt-4.2.5-bin-i386-osx-mac.dmg")
+  (check-equal? (hash-ref legacy-req-4.2.5-mac 'installer-filename)
+                "plt-4.2.5-bin-i386-osx-mac.dmg")
+  (check-equal? (hash-ref legacy-req-4.2.5-mac 'legacy-install-kind) 'dmg)
+  (check-equal? (hash-ref legacy-req-4.2.5-mac 'platform) "macosx")
+
+  ;; macOS DMGs available for 350+, not for older versions
+  (define legacy-req-350-mac (resolve-install-request/runtime "350" #:arch "i386" #:platform "macosx"))
+  (check-equal? (hash-ref legacy-req-350-mac 'legacy-install-kind) 'dmg)
+  (check-exn #px"does not have macOS installers"
+             (lambda () (resolve-install-request/runtime "209" #:arch "i386" #:platform "macosx")))
+
+  ;; Spot-check a few more macOS entries resolve correctly
+  (for ([ver (in-list '("4.0" "4.1" "4.2" "370" "372"))])
+    (define req (resolve-install-request/runtime ver #:arch "i386" #:platform "macosx"))
+    (check-equal? (hash-ref req 'legacy-install-kind) 'dmg
+                  (format "~a macOS should use dmg install kind" ver))
+    (check-true (regexp-match? #rx"osx-mac\\.dmg$" (hash-ref req 'installer-filename))
+                (format "~a macOS filename should end with osx-mac.dmg" ver)))
+
   (for* ([release-info (in-hash-values legacy-plt-release-info)]
          [artifact (in-list (hash-ref release-info 'artifacts null))]
          #:when (regexp-match? #px"^http://" (hash-ref artifact 'url "")))

--- a/test/remote.rkt
+++ b/test/remote.rkt
@@ -348,4 +348,89 @@
    #px"PLT Scheme v102|historical release range"
    (lambda () (resolve-install-request/runtime "102" #:arch "i386")))
   (check-exn exn:fail?
-             (lambda () (resolve-install-request/runtime "203" #:arch "i386"))))
+             (lambda () (resolve-install-request/runtime "203" #:arch "i386")))
+
+  ;; Extension preference: select-installer-filename/by-ext with macOS extensions
+  (define fake-table-macos
+    (hash 'a "racket-9.1-aarch64-macosx-cs.tgz"
+          'b "racket-9.1-aarch64-macosx-cs.dmg"
+          'c "racket-minimal-9.1-aarch64-macosx-cs.tgz"
+          'd "racket-minimal-9.1-aarch64-macosx-cs.dmg"
+          'e "racket-9.1-x86_64-macosx-cs.tgz"
+          'f "racket-9.1-x86_64-macosx-cs.dmg"))
+
+  ;; On macOS, tgz is preferred over dmg
+  (check-equal? (select-installer-filename fake-table-macos
+                                           #:version-token "9.1"
+                                           #:variant 'cs
+                                           #:distribution 'full
+                                           #:arch "aarch64"
+                                           #:platform "macosx"
+                                           #:ext "tgz")
+                "racket-9.1-aarch64-macosx-cs.tgz")
+
+  ;; dmg fallback works
+  (check-equal? (select-installer-filename fake-table-macos
+                                           #:version-token "9.1"
+                                           #:variant 'cs
+                                           #:distribution 'full
+                                           #:arch "aarch64"
+                                           #:platform "macosx"
+                                           #:ext "dmg")
+                "racket-9.1-aarch64-macosx-cs.dmg")
+
+  ;; select-installer-filename/by-ext prefers tgz over dmg for macOS
+  (check-equal? (select-installer-filename/by-ext fake-table-macos
+                                                   #:version-token "9.1"
+                                                   #:variant 'cs
+                                                   #:distribution 'full
+                                                   #:arch "aarch64"
+                                                   #:platform "macosx"
+                                                   #:exts '("tgz" "dmg"))
+                "racket-9.1-aarch64-macosx-cs.tgz")
+
+  ;; dmg-only table falls back correctly
+  (define fake-table-macos-dmg-only
+    (hash 'a "racket-9.1-aarch64-macosx-cs.dmg"))
+  (check-equal? (select-installer-filename/by-ext fake-table-macos-dmg-only
+                                                   #:version-token "9.1"
+                                                   #:variant 'cs
+                                                   #:distribution 'full
+                                                   #:arch "aarch64"
+                                                   #:platform "macosx"
+                                                   #:exts '("tgz" "dmg"))
+                "racket-9.1-aarch64-macosx-cs.dmg")
+
+  ;; macOS platform should not select Linux sh installers
+  (define fake-table-cross-platform
+    (hash 'a "racket-9.1-x86_64-linux-cs.sh"
+          'b "racket-9.1-x86_64-macosx-cs.tgz"))
+  (check-exn exn:fail?
+             (lambda ()
+               (select-installer-filename fake-table-cross-platform
+                                          #:version-token "9.1"
+                                          #:variant 'cs
+                                          #:distribution 'full
+                                          #:arch "x86_64"
+                                          #:platform "macosx"
+                                          #:ext "sh")))
+
+  ;; Linux platform should not select macOS dmg installers
+  (check-exn exn:fail?
+             (lambda ()
+               (select-installer-filename fake-table-cross-platform
+                                          #:version-token "9.1"
+                                          #:variant 'cs
+                                          #:distribution 'full
+                                          #:arch "x86_64"
+                                          #:platform "linux"
+                                          #:ext "dmg")))
+
+  ;; Parsing macOS dmg filenames
+  (define p-macos-dmg (parse-installer-filename "racket-9.1-aarch64-macosx-cs.dmg"))
+  (check-equal? (hash-ref p-macos-dmg 'arch) "aarch64")
+  (check-equal? (hash-ref p-macos-dmg 'platform) "macosx")
+  (check-equal? (hash-ref p-macos-dmg 'platform-family) "macosx")
+  (check-equal? (hash-ref p-macos-dmg 'variant) 'cs)
+  (check-equal? (hash-ref p-macos-dmg 'ext) "dmg")
+  (check-equal? (hash-ref p-macos-dmg 'distribution) 'full)))

--- a/test/remote.rkt
+++ b/test/remote.rkt
@@ -433,4 +433,4 @@
   (check-equal? (hash-ref p-macos-dmg 'platform-family) "macosx")
   (check-equal? (hash-ref p-macos-dmg 'variant) 'cs)
   (check-equal? (hash-ref p-macos-dmg 'ext) "dmg")
-  (check-equal? (hash-ref p-macos-dmg 'distribution) 'full)))
+  (check-equal? (hash-ref p-macos-dmg 'distribution) 'full))

--- a/test/remote.rkt
+++ b/test/remote.rkt
@@ -265,7 +265,7 @@
     "209")
    "plt-209-bin-i386-linux-gcc2.sh")
 
-  (define legacy-req-209 (resolve-install-request/runtime "209" #:arch "i386"))
+  (define legacy-req-209 (resolve-install-request/runtime "209" #:arch "i386" #:platform "linux"))
   (check-equal? (hash-ref legacy-req-209 'installer-url)
                 "http://download.plt-scheme.org/bundles/209/plt/plt-209-bin-i386-linux.sh")
   (check-equal? (hash-ref legacy-req-209 'installer-filename)
@@ -274,7 +274,7 @@
                 "f70696da6302a9ca22a3df1fc9c951689f07669643859768489a372c04aef5c9")
   (check-equal? (hash-ref legacy-req-209 'legacy-install-kind) 'shell-basic)
 
-  (define legacy-req-103p1 (resolve-install-request/runtime "103p1" #:arch "i386"))
+  (define legacy-req-103p1 (resolve-install-request/runtime "103p1" #:arch "i386" #:platform "linux"))
   (check-equal? (hash-ref legacy-req-103p1 'installer-url)
                 "http://download.plt-scheme.org/bundles/103p1/plt/plt-103p1-bin-i386-linux.tgz")
   (check-equal? (hash-ref legacy-req-103p1 'installer-filename)
@@ -283,7 +283,7 @@
                 "7090e2d7df07c17530e50cbc5fde67b51b39f77c162b7f20413242dca923a20a")
   (check-equal? (hash-ref legacy-req-103p1 'legacy-install-kind) 'tgz)
 
-  (define legacy-req-4.2.5 (resolve-install-request/runtime "4.2.5" #:arch "x86_64"))
+  (define legacy-req-4.2.5 (resolve-install-request/runtime "4.2.5" #:arch "x86_64" #:platform "linux"))
   (check-equal? (hash-ref legacy-req-4.2.5 'installer-url)
                 "http://download.plt-scheme.org/bundles/4.2.5/plt/plt-4.2.5-bin-x86_64-linux-f7.sh")
   (check-equal? (hash-ref legacy-req-4.2.5 'legacy-install-kind) 'shell-unixstyle)
@@ -343,12 +343,12 @@
         (ensure-installer-cached/runtime-private "http://download.plt-scheme.org/example.sh")))))
 
   (check-exn exn:fail?
-             (lambda () (resolve-install-request/runtime "053" #:arch "i386")))
+             (lambda () (resolve-install-request/runtime "053" #:arch "i386" #:platform "linux")))
   (check-exn
    #px"PLT Scheme v102|historical release range"
-   (lambda () (resolve-install-request/runtime "102" #:arch "i386")))
+   (lambda () (resolve-install-request/runtime "102" #:arch "i386" #:platform "linux")))
   (check-exn exn:fail?
-             (lambda () (resolve-install-request/runtime "203" #:arch "i386")))
+             (lambda () (resolve-install-request/runtime "203" #:arch "i386" #:platform "linux")))
 
   ;; Extension preference: select-installer-filename/by-ext with macOS extensions
   (define fake-table-macos

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -1054,6 +1054,7 @@
               --set-default           Set installed toolchain as the global default.
               --force                 Reinstall if the same canonical toolchain is already installed.
               --no-cache              Redownload installer instead of using cache.
+              --installer-ext sh|tgz|dmg  Force installer extension (default: platform-dependent).
               --quiet                 Show minimal output (errors + final result lines).
               --verbose               Show detailed installer URL/path output.
 

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -1008,7 +1008,7 @@
          (run-linux-installer! installer dest #:legacy-install-kind 'shell-basic)
          #f))
      (check-true (string? msg))
-     (check-true (string-contains? msg "linux-installer failed"))))
+     (check-true (string-contains? msg "installer failed"))))
 
   (with-temp-rackup-home
    (lambda (tmp)

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -1023,7 +1023,7 @@
                         "#!/usr/bin/env bash\necho tgz-runtime\n")
      (file-or-directory-permissions (build-path archive-root "racket" "bin" "racket") #o755)
      (check-true (system* tar-exe "-czf" archive "-C" archive-root "."))
-     (run-linux-tgz-installer! archive dest)
+     (run-tgz-installer! archive dest)
      (check-true (directory-exists? (build-path dest "racket" "bin")))
      (check-true (file-exists? (build-path dest "racket" "bin" "racket")))))
 

--- a/test/versioning.rkt
+++ b/test/versioning.rkt
@@ -48,8 +48,8 @@
                 "snapshot-utah-20260225-abcd-8.19.0.1-cs-x86_64-linux-full")
 
   ;; host-platform-token returns a recognized platform string
-  (check-true (member (host-platform-token) '("linux" "macosx"))
-              "host-platform-token must return a recognized platform")
+  (check-not-false (member (host-platform-token) '("linux" "macosx"))
+                   "host-platform-token must return a recognized platform")
 
   ;; macOS canonical IDs use "macosx" platform token
   (check-equal? (canonical-toolchain-id 'release

--- a/test/versioning.rkt
+++ b/test/versioning.rkt
@@ -45,4 +45,25 @@
                                         #:distribution 'full
                                         #:snapshot-site 'utah
                                         #:snapshot-stamp "20260225-abcd")
-                "snapshot-utah-20260225-abcd-8.19.0.1-cs-x86_64-linux-full"))
+                "snapshot-utah-20260225-abcd-8.19.0.1-cs-x86_64-linux-full")
+
+  ;; host-platform-token returns a recognized platform string
+  (check-true (member (host-platform-token) '("linux" "macosx"))
+              "host-platform-token must return a recognized platform")
+
+  ;; macOS canonical IDs use "macosx" platform token
+  (check-equal? (canonical-toolchain-id 'release
+                                        #:resolved-version "9.1"
+                                        #:variant 'cs
+                                        #:arch "aarch64"
+                                        #:platform "macosx"
+                                        #:distribution 'full)
+                "release-9.1-cs-aarch64-macosx-full")
+
+  (check-equal? (canonical-toolchain-id 'release
+                                        #:resolved-version "8.18"
+                                        #:variant 'cs
+                                        #:arch "x86_64"
+                                        #:platform "macosx"
+                                        #:distribution 'minimal)
+                "release-8.18-cs-x86_64-macosx-minimal"))


### PR DESCRIPTION
## Summary
This PR adds comprehensive macOS support to rackup, including detection of the host platform, selection of appropriate installer formats (tgz/dmg), and handling of DMG file extraction for macOS installations.

## Key Changes

- **Platform Detection**: Added `rackup_host_platform()` function in the bootstrap script and `host-platform-token()` in Racket code to detect whether the system is Linux or macOS, replacing hardcoded "linux" references.

- **Installer Format Selection**: 
  - Modified installer selection logic to prefer `.tgz` over `.dmg` on macOS (with `.dmg` as fallback)
  - Linux continues to prefer `.sh` over `.tgz`
  - Platform-specific filtering ensures macOS doesn't select Linux installers and vice versa

- **DMG Installer Support**: 
  - Implemented `run-macos-dmg-installer!()` function to mount DMG files, locate the Racket installation directory within the mount, and copy files to the installation root
  - Added DMG handling in both the main installer (`install.rkt`) and hidden runtime installer (`runtime.rkt`)
  - Proper cleanup of mount points using `hdiutil detach`

- **Bootstrap Script Updates**:
  - Enhanced `rackup_select_hidden_runtime_filename()` to handle platform-specific installer selection
  - Updated runtime ID generation to include the detected platform token instead of hardcoded "linux"
  - Added DMG extraction logic with proper directory detection for Racket's standard layout

- **CI/Testing**:
  - Added macOS test matrix covering macOS 13 (Intel), 14, and 15 (Apple Silicon)
  - Added E2E tests for both tgz and dmg installer paths on macOS
  - Added bootstrap test for macOS without pre-installed Racket
  - Extended unit tests to verify macOS installer filename parsing and selection logic

- **API Updates**: Added optional `#:installer-ext` parameter to `resolve-install-request/runtime` to allow forcing specific installer formats, and `#:platform` parameter to installer selection functions for testing.

## Implementation Details

- The DMG mounting uses `hdiutil attach` with flags to prevent automatic opening and browsing
- Handles variable DMG layouts: looks for a subdirectory with `bin/`, falls back to root `bin/`, or uses the first directory
- Uses `dynamic-wind` to ensure DMG is properly unmounted even if extraction fails
- Platform token "macosx" is used consistently throughout to match Racket's download filename conventions
- Maintains backward compatibility with existing Linux installation paths

https://claude.ai/code/session_01PVAwF6QQ69x2H1s8Q4epCd