### PR TITLE
Work around cross-compilation bug with raco cross make

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -15,28 +15,16 @@ jobs:
           - runs_on: ubuntu-latest
             artifact_name: x86_64-linux
             setup_racket_arch: x64
-            cross_target: ""
           - runs_on: ubuntu-24.04-arm
             artifact_name: aarch64-linux
             setup_racket_arch: arm64
-            cross_target: ""
           - runs_on: macos-15-intel
             artifact_name: x86_64-macosx
             setup_racket_arch: x64
-            cross_target: ""
           - runs_on: macos-14
             artifact_name: aarch64-macosx
             setup_racket_arch: arm64
-            cross_target: ""
-          # Cross-compiled builds for platforms without native GHA runners.
-          - runs_on: ubuntu-latest
-            artifact_name: arm32-linux
-            setup_racket_arch: x64
-            cross_target: arm32-linux
-          - runs_on: ubuntu-latest
-            artifact_name: i386-linux
-            setup_racket_arch: x64
-            cross_target: i386-linux
+          # Other platforms use source distribution (no exe build needed)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -47,24 +35,13 @@ jobs:
           distribution: full
           variant: CS
           version: stable
-      - name: Install raco cross (cross-compilation only)
-        if: matrix.cross_target != ''
-        shell: bash
-        run: raco pkg install --auto raco-cross
       - name: Build executable distribution
         shell: bash
         run: |
           mkdir -p dist
-          if [ -n "${{ matrix.cross_target }}" ]; then
-            scripts/build-dist.sh \
-              --cross "${{ matrix.cross_target }}" \
-              --output "dist/rackup-${{ matrix.artifact_name }}.tar.gz"
-          else
-            scripts/build-dist.sh \
-              --output "dist/rackup-${{ matrix.artifact_name }}.tar.gz"
-          fi
-      - name: Smoke test (native builds only)
-        if: matrix.cross_target == ''
+          scripts/build-dist.sh \
+            --output "dist/rackup-${{ matrix.artifact_name }}.tar.gz"
+      - name: Smoke test
         shell: bash
         run: |
           mkdir -p /tmp/rackup-exe-test

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -29,17 +29,14 @@ jobs:
             setup_racket_arch: arm64
             cross_target: ""
           # Cross-compiled builds for platforms without native GHA runners.
-          # Disabled: raco cross exe fails with "fasl-read: incompatible
-          # fasl-object machine-type" in the setup-racket CI environment.
-          # See https://github.com/samth/rackup/issues/TBD
-          # - runs_on: ubuntu-latest
-          #   artifact_name: arm32-linux
-          #   setup_racket_arch: x64
-          #   cross_target: arm32-linux
-          # - runs_on: ubuntu-latest
-          #   artifact_name: i386-linux
-          #   setup_racket_arch: x64
-          #   cross_target: i386-linux
+          - runs_on: ubuntu-latest
+            artifact_name: arm32-linux
+            setup_racket_arch: x64
+            cross_target: arm32-linux
+          - runs_on: ubuntu-latest
+            artifact_name: i386-linux
+            setup_racket_arch: x64
+            cross_target: i386-linux
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -95,6 +95,12 @@ echo "Building rackup binary distribution..."
 # Step 1: Compile with raco exe
 if [ -n "$CROSS_TARGET" ]; then
   echo "Cross-compiling for target: $CROSS_TARGET"
+  # Pre-compile for the target to produce .zo files. Without this,
+  # raco exe falls back to compiling from source with the cross target,
+  # which hits a Racket expander bug (fasl-read incompatible machine-type)
+  # for modules with define-syntaxes + module*.
+  "$RACO" cross --target "$CROSS_TARGET" make \
+    "$ROOT_DIR/libexec/rackup-core.rkt"
   "$RACO" cross --target "$CROSS_TARGET" exe \
     -o "$BUILD_DIR/rackup-core" \
     "$ROOT_DIR/libexec/rackup-core.rkt"

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -3,11 +3,8 @@ set -eu
 
 # Build a prebuilt binary distribution of rackup using raco exe + raco distribute.
 #
-# Native build (on the target platform):
+# Usage:
 #   scripts/build-dist.sh --output dist/rackup-x86_64-linux.tar.gz
-#
-# Cross-compile (from any platform with raco cross installed):
-#   scripts/build-dist.sh --cross i386-linux --output dist/rackup-i386-linux.tar.gz
 #
 # The output tarball contains:
 #   rackup/
@@ -16,36 +13,26 @@ set -eu
 #     lib/...             (shared libraries from raco distribute)
 #     libexec/rackup-bootstrap.sh (shell helpers for prompt/arch detection)
 
-CROSS_TARGET=""
 OUTPUT=""
 RACKET="${RACKET:-racket}"
 RACO="${RACO:-raco}"
 
 usage() {
   cat <<'USAGE'
-Usage: build-dist.sh [--cross TARGET] --output FILE
+Usage: build-dist.sh --output FILE
 
 Options:
-  --cross TARGET   Cross-compile for TARGET using raco cross --target.
-                   TARGET is a raco cross platform name, e.g. i386-linux, aarch64-linux.
   --output FILE    Output tarball path (e.g. dist/rackup-x86_64-linux.tar.gz).
   --racket EXE     Path to racket executable (default: racket).
   --raco EXE       Path to raco executable (default: raco).
 
-Native build example:
+Example:
   scripts/build-dist.sh --output dist/rackup-x86_64-linux.tar.gz
-
-Cross-compile example:
-  scripts/build-dist.sh --cross i386-linux --output dist/rackup-i386-linux.tar.gz
 USAGE
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --cross)
-      CROSS_TARGET="$2"
-      shift 2
-      ;;
     --output)
       OUTPUT="$2"
       shift 2
@@ -93,31 +80,11 @@ mkdir -p "$BUILD_DIR" "$DIST_DIR" "$STAGE_DIR"
 echo "Building rackup binary distribution..."
 
 # Step 1: Compile with raco exe
-if [ -n "$CROSS_TARGET" ]; then
-  echo "Cross-compiling for target: $CROSS_TARGET"
-  # Pre-compile for the target to produce .zo files. Without this,
-  # raco exe falls back to compiling from source with the cross target,
-  # which hits a Racket expander bug (fasl-read incompatible machine-type)
-  # for modules with define-syntaxes + module*.
-  "$RACO" cross --target "$CROSS_TARGET" make \
-    "$ROOT_DIR/libexec/rackup-core.rkt"
-  "$RACO" cross --target "$CROSS_TARGET" exe \
-    -o "$BUILD_DIR/rackup-core" \
-    "$ROOT_DIR/libexec/rackup-core.rkt"
-else
-  echo "Native compilation..."
-  "$RACO" exe -o "$BUILD_DIR/rackup-core" \
-    "$ROOT_DIR/libexec/rackup-core.rkt"
-fi
+"$RACO" exe -o "$BUILD_DIR/rackup-core" \
+  "$ROOT_DIR/libexec/rackup-core.rkt"
 
 # Step 2: Create distributable with raco distribute
-if [ -n "$CROSS_TARGET" ]; then
-  "$RACO" cross --target "$CROSS_TARGET" distribute \
-    "$DIST_DIR" \
-    "$BUILD_DIR/rackup-core"
-else
-  "$RACO" distribute "$DIST_DIR" "$BUILD_DIR/rackup-core"
-fi
+"$RACO" distribute "$DIST_DIR" "$BUILD_DIR/rackup-core"
 
 # Step 3: Assemble the final distribution layout
 #   rackup/


### PR DESCRIPTION
## Summary
- Pre-compile with `raco cross make` before `raco cross exe` to work around Racket expander bug
- Re-enable arm32-linux and i386-linux cross-compilation targets in CI

## Background
`raco cross exe` fails with `fasl-read: incompatible fasl-object machine-type` when it has to compile modules from source. The root cause is in the Racket expander's `declare-module-for-expansion`, which cross-compiles linklets that can't be instantiated on the host. Pre-compiling with `raco cross make` produces .zo files so the embedder reads them directly, bypassing the bug.

## Test plan
- [ ] CI passes for arm32-linux and i386-linux cross-compilation targets
- [ ] Native builds (x86_64-linux, aarch64-linux, x86_64-macosx, aarch64-macosx) still pass