### PR TITLE
Re-enable cross-compiled exe targets (arm32-linux, i386-linux)

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -15,16 +15,28 @@ jobs:
           - runs_on: ubuntu-latest
             artifact_name: x86_64-linux
             setup_racket_arch: x64
+            cross_target: ""
           - runs_on: ubuntu-24.04-arm
             artifact_name: aarch64-linux
             setup_racket_arch: arm64
+            cross_target: ""
           - runs_on: macos-15-intel
             artifact_name: x86_64-macosx
             setup_racket_arch: x64
+            cross_target: ""
           - runs_on: macos-14
             artifact_name: aarch64-macosx
             setup_racket_arch: arm64
-          # Other platforms use source distribution (no exe build needed)
+            cross_target: ""
+          # Cross-compiled builds for platforms without native GHA runners.
+          - runs_on: ubuntu-latest
+            artifact_name: arm32-linux
+            setup_racket_arch: x64
+            cross_target: arm32-linux
+          - runs_on: ubuntu-latest
+            artifact_name: i386-linux
+            setup_racket_arch: x64
+            cross_target: i386-linux
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -35,13 +47,24 @@ jobs:
           distribution: full
           variant: CS
           version: stable
+      - name: Install raco cross (cross-compilation only)
+        if: matrix.cross_target != ''
+        shell: bash
+        run: raco pkg install --auto raco-cross
       - name: Build executable distribution
         shell: bash
         run: |
           mkdir -p dist
-          scripts/build-dist.sh \
-            --output "dist/rackup-${{ matrix.artifact_name }}.tar.gz"
-      - name: Smoke test
+          if [ -n "${{ matrix.cross_target }}" ]; then
+            scripts/build-dist.sh \
+              --cross "${{ matrix.cross_target }}" \
+              --output "dist/rackup-${{ matrix.artifact_name }}.tar.gz"
+          else
+            scripts/build-dist.sh \
+              --output "dist/rackup-${{ matrix.artifact_name }}.tar.gz"
+          fi
+      - name: Smoke test (native builds only)
+        if: matrix.cross_target == ''
         shell: bash
         run: |
           mkdir -p /tmp/rackup-exe-test
@@ -49,6 +72,30 @@ jobs:
           export RACKUP_HOME=/tmp/rackup-exe-test/rackup
           /tmp/rackup-exe-test/rackup/bin/rackup version
           /tmp/rackup-exe-test/rackup/bin/rackup help
+      - name: Set up QEMU (cross builds only)
+        if: matrix.cross_target != ''
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm,386
+      - name: Smoke test via QEMU (cross builds only)
+        if: matrix.cross_target != ''
+        shell: bash
+        run: |
+          case "${{ matrix.cross_target }}" in
+            arm32-linux) DOCKER_PLATFORM="linux/arm/v7" ; BASE_IMAGE="debian:12" ;;
+            i386-linux)  DOCKER_PLATFORM="linux/386"     ; BASE_IMAGE="debian:12" ;;
+            *) echo "Unknown cross target: ${{ matrix.cross_target }}" >&2; exit 1 ;;
+          esac
+          mkdir -p /tmp/rackup-exe-test
+          tar -xzf "dist/rackup-${{ matrix.artifact_name }}.tar.gz" -C /tmp/rackup-exe-test
+          docker run --rm --platform "$DOCKER_PLATFORM" \
+            -v /tmp/rackup-exe-test/rackup:/rackup:ro \
+            -e RACKUP_HOME=/rackup \
+            "$BASE_IMAGE" /rackup/bin/rackup version
+          docker run --rm --platform "$DOCKER_PLATFORM" \
+            -v /tmp/rackup-exe-test/rackup:/rackup:ro \
+            -e RACKUP_HOME=/rackup \
+            "$BASE_IMAGE" /rackup/bin/rackup help
       - name: Upload exe artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -3,8 +3,11 @@ set -eu
 
 # Build a prebuilt binary distribution of rackup using raco exe + raco distribute.
 #
-# Usage:
+# Native build (on the target platform):
 #   scripts/build-dist.sh --output dist/rackup-x86_64-linux.tar.gz
+#
+# Cross-compile (from any platform with raco cross installed):
+#   scripts/build-dist.sh --cross i386-linux --output dist/rackup-i386-linux.tar.gz
 #
 # The output tarball contains:
 #   rackup/
@@ -13,26 +16,36 @@ set -eu
 #     lib/...             (shared libraries from raco distribute)
 #     libexec/rackup-bootstrap.sh (shell helpers for prompt/arch detection)
 
+CROSS_TARGET=""
 OUTPUT=""
 RACKET="${RACKET:-racket}"
 RACO="${RACO:-raco}"
 
 usage() {
   cat <<'USAGE'
-Usage: build-dist.sh --output FILE
+Usage: build-dist.sh [--cross TARGET] --output FILE
 
 Options:
+  --cross TARGET   Cross-compile for TARGET using raco cross --target.
+                   TARGET is a raco cross platform name, e.g. i386-linux, arm32-linux.
   --output FILE    Output tarball path (e.g. dist/rackup-x86_64-linux.tar.gz).
   --racket EXE     Path to racket executable (default: racket).
   --raco EXE       Path to raco executable (default: raco).
 
-Example:
+Native build example:
   scripts/build-dist.sh --output dist/rackup-x86_64-linux.tar.gz
+
+Cross-compile example:
+  scripts/build-dist.sh --cross i386-linux --output dist/rackup-i386-linux.tar.gz
 USAGE
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --cross)
+      CROSS_TARGET="$2"
+      shift 2
+      ;;
     --output)
       OUTPUT="$2"
       shift 2
@@ -94,11 +107,30 @@ if [ -n "$COMMIT" ]; then
 fi
 
 # Step 1: Compile with raco exe
-"$RACO" exe -o "$BUILD_DIR/rackup-core" \
-  "$ROOT_DIR/libexec/rackup-core.rkt"
+if [ -n "$CROSS_TARGET" ]; then
+  echo "Cross-compiling for target: $CROSS_TARGET"
+  # Pre-compile for the target to produce .zo files. Without this,
+  # raco exe falls back to compiling from source with the cross target,
+  # which hits a Racket expander bug (fasl-read incompatible machine-type)
+  # for modules with define-syntaxes + module*.
+  "$RACO" cross --target "$CROSS_TARGET" make \
+    "$ROOT_DIR/libexec/rackup-core.rkt"
+  "$RACO" cross --target "$CROSS_TARGET" exe \
+    -o "$BUILD_DIR/rackup-core" \
+    "$ROOT_DIR/libexec/rackup-core.rkt"
+else
+  "$RACO" exe -o "$BUILD_DIR/rackup-core" \
+    "$ROOT_DIR/libexec/rackup-core.rkt"
+fi
 
 # Step 2: Create distributable with raco distribute
-"$RACO" distribute "$DIST_DIR" "$BUILD_DIR/rackup-core"
+if [ -n "$CROSS_TARGET" ]; then
+  "$RACO" cross --target "$CROSS_TARGET" distribute \
+    "$DIST_DIR" \
+    "$BUILD_DIR/rackup-core"
+else
+  "$RACO" distribute "$DIST_DIR" "$BUILD_DIR/rackup-core"
+fi
 
 # Step 3: Assemble the final distribution layout
 #   rackup/


### PR DESCRIPTION
## Summary

- Re-enable arm32-linux and i386-linux cross-compiled exe builds in CI
- Restore `--cross` support in `build-dist.sh`
- Use `raco cross make` workaround for raco-cross#14 (fasl-read incompatible machine-type bug)
- Add QEMU-based smoke tests for cross-compiled binaries to gate page deployment

## Details

Cross-compiled binaries are validated via QEMU before the pages-build job runs (`pages-build` depends on `build-exe`). Each cross build:
1. Installs raco-cross
2. Pre-compiles with `raco cross make` (workaround for the expander bug)
3. Builds with `raco cross exe` + `raco cross distribute`
4. Smoke tests the resulting binary under QEMU (docker with `--platform`)

## Test plan

- [ ] CI: arm32-linux cross-compilation succeeds
- [ ] CI: arm32-linux QEMU smoke test passes (`rackup version`, `rackup help`)
- [ ] CI: i386-linux cross-compilation succeeds
- [ ] CI: i386-linux QEMU smoke test passes
- [ ] CI: native builds unchanged
- [ ] CI: pages-build only runs after all exe builds (including cross) pass