### PR TITLE
Stop setting PLTHOME and PLTCOLLECTS for toolchains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,20 @@ raco test -y test/all.rkt           # run all unit tests
 raco test -y test/<name>.rkt        # run a single test file
 ```
 
+### Shell linting
+
+Run before pushing changes to shell scripts (`*.sh`, `bin/rackup`):
+
+```bash
+# ShellCheck (catches bugs and warnings)
+find . -name '*.sh' -type f -print0 | xargs -0 shellcheck --severity=warning
+shellcheck --severity=warning bin/rackup
+
+# shfmt (formatting)
+find . -name '*.sh' -type f -print0 | xargs -0 shfmt -d -i 2 -ci
+shfmt -d -i 2 -ci bin/rackup
+```
+
 ### Docker E2E tests
 
 These match what CI runs. Each invocation builds a Docker image and runs the full install/smoke test inside it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Project Instructions
 
+## Architecture
+
+See `docs/IMPLEMENTATION.md` for a detailed description of the project's design and internals.
+
 ## Git
 
 - Use `Closes #N` or `Fixes #N` in commit messages to auto-close GitHub issues.

--- a/bin/rackup
+++ b/bin/rackup
@@ -58,13 +58,13 @@ fi
 if [ -x "$CORE_EXE" ]; then
   # Save user's Racket env vars for pass-through (rackup run), then clear
   # so the embedded runtime is not affected.
-  for _rackup_v in PLTHOME PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK; do
+  for _rackup_v in PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK; do
     eval "_rackup_val=\${$_rackup_v:-}"
     if [ -n "$_rackup_val" ]; then
       eval "export _RACKUP_ORIG_$_rackup_v=\"\$_rackup_val\""
     fi
   done
-  unset PLTHOME PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK
+  unset PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK
 
   if [ "${1:-}" = "uninstall" ]; then
     REQUEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rackup-uninstall.XXXXXX")"
@@ -128,7 +128,7 @@ for _rackup_v in PLTHOME PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RA
     eval "export _RACKUP_ORIG_$_rackup_v=\"\$_rackup_val\""
   fi
 done
-unset PLTHOME PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK
+unset PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK
 
 rackup_run_core() {
   if [ "$USE_Y" -eq 1 ]; then

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -88,15 +88,15 @@ The `.rktd` reader disables `read-accept-reader`, `read-accept-lang`, and `read-
 
 ## Environment variable isolation
 
-When `bin/rackup` starts, it saves any user-set Racket environment variables (`PLTHOME`, `PLTCOLLECTS`, `PLTADDONDIR`, `PLTCOMPILEDROOTS`, `PLTUSERHOME`, `RACKET_XPATCH`, `PLT_COMPILED_FILE_CHECK`) as `_RACKUP_ORIG_*` and then unsets the originals. This prevents the user's Racket environment from interfering with rackup's own runtime (whether hidden runtime or embedded exe).
+When `bin/rackup` starts, it saves any user-set Racket environment variables (`PLTCOLLECTS`, `PLTADDONDIR`, `PLTCOMPILEDROOTS`, `PLTUSERHOME`, `RACKET_XPATCH`, `PLT_COMPILED_FILE_CHECK`) as `_RACKUP_ORIG_*` and then unsets the originals. This prevents the user's Racket environment from interfering with rackup's own runtime (whether hidden runtime or embedded exe). `PLTHOME` is not included because it is not a Racket environment variable (it is a convention from the `plt-bin` script in `racket-dev-goodies`).
 
-When `rackup run` spawns a subprocess, `restore-saved-racket-env-vars!` in `util.rkt` first restores the user's original Racket environment variables from the `_RACKUP_ORIG_*` copies. Then `cmd-run` overlays the target toolchain's managed environment variables on top (including `PLTADDONDIR`, `PLTHOME`, and `PLTCOLLECTS` from the toolchain's env-vars). The toolchain-managed values take precedence over the restored originals.
+When `rackup run` spawns a subprocess, `restore-saved-racket-env-vars!` in `util.rkt` first restores the user's original Racket environment variables from the `_RACKUP_ORIG_*` copies. Then `cmd-run` overlays the target toolchain's managed environment variables on top (currently only `PLTADDONDIR`). This means a user-set `PLTCOLLECTS` passes through to the toolchain's Racket, allowing users to add collection directories that are available regardless of which toolchain is active.
 
 ## Per-toolchain env.sh
 
-The shim dispatcher sources a per-toolchain `env.sh` file if present. For installed (release/snapshot) toolchains, this file is computed once at install time. For linked (local) toolchains, the env file is regenerated on every `reshim!` call by `regenerate-env-files!` in `shims.rkt`, because the source tree layout may change. If a local toolchain has no derivable env vars (e.g., the source root cannot be located), the env file is deleted rather than written empty.
+The shim dispatcher sources a per-toolchain `env.sh` file if present. For linked (local) toolchains, the env file is regenerated on every `reshim!` call by `regenerate-env-files!` in `shims.rkt`, because the source tree layout may change. If a local toolchain has no derivable env vars (e.g., the source root cannot be located), the env file is deleted rather than written empty. Installed (release/snapshot) toolchains do not have env files.
 
-The env file conditionally exports `PLTHOME`, `PLTCOLLECTS`, and `PLTADDONDIR` — each key is only emitted when a value can be computed. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`). The `PLTCOLLECTS` value, when set, points at the bare collects directory (not the search-path form with a trailing empty element) so that user-installed packages are found through the addon directory rather than through the source tree's `pkgs/` directory.
+The env file exports only `PLTADDONDIR` when a value can be computed. Neither `PLTHOME` nor `PLTCOLLECTS` is set — the Racket binary finds its own collections via compiled-in relative paths, and `PLTHOME` is not a Racket environment variable. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`).
 
 ## Shell integration
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -96,7 +96,7 @@ When `rackup run` spawns a subprocess, `restore-saved-racket-env-vars!` in `util
 
 The shim dispatcher sources a per-toolchain `env.sh` file if present. For linked (local) toolchains, the env file is regenerated on every `reshim!` call by `regenerate-env-files!` in `shims.rkt`, because the source tree layout may change. If a local toolchain has no derivable env vars (e.g., the source root cannot be located), the env file is deleted rather than written empty. Installed (release/snapshot) toolchains do not have env files.
 
-The env file exports only `PLTADDONDIR` when a value can be computed. Neither `PLTHOME` nor `PLTCOLLECTS` is set — the Racket binary finds its own collections via compiled-in relative paths, and `PLTHOME` is not a Racket environment variable. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`).
+The env file exports only `PLTADDONDIR` when a value can be computed. Neither `PLTHOME` nor `PLTCOLLECTS` is set — the Racket binary finds its own collections via compiled-in relative paths, and `PLTHOME` is not a Racket environment variable. The one exception is old PLT Scheme installations (version <= 4.x) where the parent directory is named `plt`: these set `PLTHOME` because PLT Scheme's `bin/mzscheme` shell wrapper uses it to locate the real binary under `.bin/<archsys>/`. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`).
 
 ## Shell integration
 

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -593,6 +593,24 @@
           (normalize-vm-name variant-out)
           (and addon-out (not (string-blank? addon-out)) addon-out)))
 
+;; Old PLT Scheme installations (version <= 4.x) have a shell wrapper at
+;; plt/bin/mzscheme that uses $PLTHOME to locate the real binary under
+;; plt/.bin/<archsys>/. Set PLTHOME for these so the wrapper works.
+(define (installed-toolchain-env-vars real-bin-dir)
+  (define plthome (maybe-parent real-bin-dir))
+  (define-values (plthome-base plthome-leaf _plthome-dir?)
+    (if plthome
+        (split-path plthome)
+        (values #f #f #f)))
+  (define plthome-name
+    (and (path? plthome-leaf) (path->string plthome-leaf)))
+  (define plthome-normalized
+    (and plthome-base (path? plthome-leaf) (build-path plthome-base plthome-leaf)))
+  (cond
+    [(and plthome-normalized (equal? plthome-name "plt"))
+     (list (cons "PLTHOME" (path->string* plthome-normalized)))]
+    [else null]))
+
 (define (toolchain-meta request id real-bin-dir executables [env-vars null])
   (hash 'id
         id
@@ -905,10 +923,13 @@
          (define real-bin-dir (detect-bin-dir install-root))
          (maybe-modernize-legacy-archsys! real-bin-dir)
          (make-bin-link! id real-bin-dir)
-         (delete-toolchain-env-file! id)
+         (define env-vars (installed-toolchain-env-vars real-bin-dir))
+         (if (pair? env-vars)
+             (write-toolchain-env-file! id env-vars)
+             (delete-toolchain-env-file! id))
          (ensure-toolchain-addon-dir! id)
          (define executables (enumerate-toolchain-executables real-bin-dir))
-         (define meta (toolchain-meta request id real-bin-dir executables))
+         (define meta (toolchain-meta request id real-bin-dir executables env-vars))
          (commit-state-change!
           (register-toolchain! id meta)
           (when explicit-default?
@@ -976,4 +997,5 @@
 
 (module+ for-testing
   (provide detect-bin-dir
+           installed-toolchain-env-vars
            ensure-installer-cached!))

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -373,9 +373,6 @@
 (define (path-complete-string p)
   (path->string* (path->complete-path p)))
 
-(define (path-join/colon paths)
-  (string-join (map path->string* paths) ":"))
-
 (define (maybe-parent p)
   (and p (path-only p)))
 
@@ -560,29 +557,16 @@
               (and (directory-exists? pkgs) (path-complete-string pkgs)))])]))
 
 (define (local-layout-env-vars layout [addon-dir #f])
-  (define collects-dir (hash-ref layout 'collects-dir))
-  (define pkgs-dir (hash-ref layout 'pkgs-dir #f))
   (define source-root (hash-ref layout 'source-root #f))
-  ;; PLTHOME should be the checkout root when linking a source tree,
-  ;; matching the plt-bin convention.  For installed-prefix layouts
-  ;; (no source-root), use the racket installation directory.
-  (define plthome-env (or source-root (hash-ref layout 'plthome)))
-  ;; Only include the collects dir in PLTCOLLECTS.  Packages in pkgs/ are
-  ;; discovered through links.rktd and do not need to be on the collection
-  ;; search path; including them causes "tool registered twice" warnings from
-  ;; raco because tools get found through both links and PLTCOLLECTS.
-  (define collects-path (path-join/colon (list collects-dir)))
   ;; For source checkouts, default PLTADDONDIR to <checkout>/add-on
   ;; (matching the plt-bin convention).
   (define effective-addon-dir
     (or addon-dir
         (and source-root
              (path->string* (build-path (string->path source-root) "add-on")))))
-  (append (list (cons "PLTHOME" plthome-env)
-                (cons "PLTCOLLECTS" collects-path))
-          (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
-              (list (cons "PLTADDONDIR" effective-addon-dir))
-              null)))
+  (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
+      (list (cons "PLTADDONDIR" effective-addon-dir))
+      null))
 
 (define (probe-local-racket-version+variant+addon-dir bin-dir env-vars)
   (define racket-exe (build-path (string->path bin-dir) "racket"))
@@ -608,21 +592,6 @@
   (values (and version-out (not (string-blank? version-out)) version-out)
           (normalize-vm-name variant-out)
           (and addon-out (not (string-blank? addon-out)) addon-out)))
-
-(define (installed-toolchain-env-vars real-bin-dir)
-  (define plthome (maybe-parent real-bin-dir))
-  (define-values (plthome-base plthome-leaf _plthome-dir?)
-    (if plthome
-        (split-path plthome)
-        (values #f #f #f)))
-  (define plthome-name
-    (and (path? plthome-leaf) (path->string plthome-leaf)))
-  (define plthome-normalized
-    (and plthome-base (path? plthome-leaf) (build-path plthome-base plthome-leaf)))
-  (cond
-    [(and plthome-normalized (equal? plthome-name "plt"))
-     (list (cons "PLTHOME" (path->string* plthome-normalized)))]
-    [else null]))
 
 (define (toolchain-meta request id real-bin-dir executables [env-vars null])
   (hash 'id
@@ -769,7 +738,7 @@
         'plthome
         (hash-ref layout 'plthome)
         'pltcollects
-        (cdr (assoc "PLTCOLLECTS" env-vars))
+        (hash-ref layout 'collects-dir)
         'install-root
         #f
         'bin-link
@@ -818,7 +787,9 @@
        (define env-vars (local-layout-env-vars layout addon-dir*))
        (make-bin-overlay! id real-bin-dir extra-exes)
        (maybe-wrap-local-chez-extra-executables! id extra-exes layout)
-       (write-toolchain-env-file! id env-vars)
+       (if (pair? env-vars)
+           (write-toolchain-env-file! id env-vars)
+           (delete-toolchain-env-file! id))
        (ensure-toolchain-addon-dir! id)
        (define executables (enumerate-toolchain-executables (rackup-toolchain-bin-link id)))
        (define meta (local-toolchain-meta id name layout real-bin-dir executables env-vars version* variant*))
@@ -934,13 +905,10 @@
          (define real-bin-dir (detect-bin-dir install-root))
          (maybe-modernize-legacy-archsys! real-bin-dir)
          (make-bin-link! id real-bin-dir)
-         (define env-vars (installed-toolchain-env-vars real-bin-dir))
-         (if (pair? env-vars)
-             (write-toolchain-env-file! id env-vars)
-             (delete-toolchain-env-file! id))
+         (delete-toolchain-env-file! id)
          (ensure-toolchain-addon-dir! id)
          (define executables (enumerate-toolchain-executables real-bin-dir))
-         (define meta (toolchain-meta request id real-bin-dir executables env-vars))
+         (define meta (toolchain-meta request id real-bin-dir executables))
          (commit-state-change!
           (register-toolchain! id meta)
           (when explicit-default?
@@ -1008,5 +976,4 @@
 
 (module+ for-testing
   (provide detect-bin-dir
-           installed-toolchain-env-vars
            ensure-installer-cached!))

--- a/libexec/rackup/shims.rkt
+++ b/libexec/rackup/shims.rkt
@@ -102,17 +102,19 @@ rackup_is_elf32() {
 
 rackup_resolve_inspect_target() {
   local target="$1" inspect_target sys candidate
+  local install_root
+  install_root="$(dirname "$BIN_REAL")"
   inspect_target="$target"
   if ! rackup_is_elf32 "$inspect_target"; then
-    if [[ -n "${PLTHOME:-}" && -d "$PLTHOME/.bin" ]]; then
-      if [[ -x "$PLTHOME/bin/archsys" ]]; then
-        sys="$("$PLTHOME/bin/archsys" z 2>/dev/null || true)"
-        if [[ -n "$sys" && -x "$PLTHOME/.bin/$sys/$SHIM_NAME" ]]; then
-          inspect_target="$PLTHOME/.bin/$sys/$SHIM_NAME"
+    if [[ -d "$install_root/.bin" ]]; then
+      if [[ -x "$install_root/bin/archsys" ]]; then
+        sys="$("$install_root/bin/archsys" z 2>/dev/null || true)"
+        if [[ -n "$sys" && -x "$install_root/.bin/$sys/$SHIM_NAME" ]]; then
+          inspect_target="$install_root/.bin/$sys/$SHIM_NAME"
         fi
       fi
       if [[ "$inspect_target" == "$target" ]]; then
-        for candidate in "$PLTHOME"/.bin/*/"$SHIM_NAME"; do
+        for candidate in "$install_root"/.bin/*/"$SHIM_NAME"; do
           if [[ -x "$candidate" ]]; then
             inspect_target="$candidate"
             break
@@ -355,19 +357,8 @@ EOF
   (when (file-exists? p)
     (delete-file p)))
 
-(define (detect-collects-dir plthome)
-  (define in-place (build-path (string->path plthome) "collects"))
-  (define prefix (build-path (string->path plthome) "share" "racket" "collects"))
-  (cond
-    [(directory-exists? in-place) (path->string* in-place)]
-    [(directory-exists? prefix) (path->string* prefix)]
-    [else #f]))
-
 (define (compute-local-env-vars meta)
-  (define plthome (hash-ref meta 'plthome #f))
   (define source-root (hash-ref meta 'source-root #f))
-  (define plthome-env (or source-root plthome))
-  (define collects-dir (and plthome (detect-collects-dir plthome)))
   (define old-env-vars (hash-ref meta 'env-vars '()))
   (define old-addon-dir
     (for/or ([kv (in-list old-env-vars)])
@@ -376,11 +367,9 @@ EOF
     (or old-addon-dir
         (and source-root
              (path->string* (build-path (string->path source-root) "add-on")))))
-  (append (if plthome-env (list (cons "PLTHOME" plthome-env)) null)
-          (if collects-dir (list (cons "PLTCOLLECTS" collects-dir)) null)
-          (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
-              (list (cons "PLTADDONDIR" effective-addon-dir))
-              null)))
+  (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
+      (list (cons "PLTADDONDIR" effective-addon-dir))
+      null))
 
 (define (regenerate-env-files!)
   (for ([id (in-list (installed-toolchain-ids))])

--- a/libexec/rackup/util.rkt
+++ b/libexec/rackup/util.rkt
@@ -136,7 +136,7 @@
 ;; so the hidden runtime is not affected. restore-saved-racket-env-vars!
 ;; puts them back for user toolchain subprocesses (rackup run).
 (define sanitized-racket-env-vars
-  '("PLTHOME" "PLTCOLLECTS" "PLTADDONDIR" "PLTCOMPILEDROOTS"
+  '("PLTCOLLECTS" "PLTADDONDIR" "PLTCOMPILEDROOTS"
     "PLTUSERHOME" "RACKET_XPATCH" "PLT_COMPILED_FILE_CHECK"))
 
 (define (restore-saved-racket-env-vars! env)

--- a/test/e2e-fresh-container.sh
+++ b/test/e2e-fresh-container.sh
@@ -641,25 +641,19 @@ else
   assert_nonempty "$linked_version" "linked source-built racket should report a version"
 fi
 echo "linked racket version=$linked_version"
+# PLTHOME and PLTCOLLECTS are not set by rackup — the binary finds its own collects.
 linked_plthome="$(shim_racket -e '(display (or (getenv "PLTHOME") ""))')"
-# In-place source layouts (racket/collects) set PLTHOME to the checkout root;
-# installed-prefix layouts (racket/share/racket/collects) keep PLTHOME as
-# the racket subdirectory since there is no source-root to use.
-if [[ -d "${local_src_root}/racket/collects" ]]; then
-  expected_plthome="${local_src_root}"
-else
-  expected_plthome="${local_src_root}/racket"
-fi
-assert_eq "$expected_plthome" "$linked_plthome" "linked shim should export PLTHOME"
+assert_eq "" "$linked_plthome" "linked shim should NOT export PLTHOME"
 linked_collects="$(shim_racket -e '(display (or (getenv "PLTCOLLECTS") ""))')"
-assert_contains "${local_collects_dir}" "$linked_collects" "linked shim should export PLTCOLLECTS"
+assert_eq "" "$linked_collects" "linked shim should NOT export PLTCOLLECTS"
 linked_addon="$(shim_racket -e '(display (or (getenv "PLTADDONDIR") ""))')"
 assert_nonempty "$linked_addon" "linked shim should export PLTADDONDIR"
 linked_addon_path="$(shim_racket -e '(display (find-system-path (quote addon-dir)))')"
 assert_eq "$linked_addon_path" "$linked_addon" "linked shim PLTADDONDIR should match the linked installation addon dir"
 echo "linked shim environment verified"
+# Verify rackup run also does not set PLTHOME
 link_run_plthome="$(run_rackup run localsrc -- racket -e '(display (or (getenv "PLTHOME") ""))')"
-assert_eq "$expected_plthome" "$link_run_plthome" "rackup run should apply linked toolchain env"
+assert_eq "" "$link_run_plthome" "rackup run should NOT set PLTHOME"
 echo "rackup run environment verified"
 if [[ "$LOCAL_LINK_MODE" == "build" ]]; then
   run_rackup run localsrc -- raco help >/dev/null

--- a/test/e2e-fresh-container.sh
+++ b/test/e2e-fresh-container.sh
@@ -621,11 +621,6 @@ case "$LOCAL_LINK_MODE" in
     fail "unsupported local link mode: $LOCAL_LINK_MODE"
     ;;
 esac
-if [[ -d "${local_src_root}/racket/share/racket/collects" ]]; then
-  local_collects_dir="${local_src_root}/racket/share/racket/collects"
-else
-  local_collects_dir="${local_src_root}/racket/collects"
-fi
 linked_id="$(run_rackup link localsrc "$local_src_root" --set-default | tail -n 1)"
 assert_eq "local-localsrc" "$linked_id" "unexpected linked toolchain id"
 echo "linked_id=$linked_id"

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -24,7 +24,7 @@
          "../libexec/rackup/util.rkt"
          "../libexec/rackup/versioning.rkt"
          (only-in (submod "../libexec/rackup/install.rkt" for-testing)
-                  detect-bin-dir installed-toolchain-env-vars)
+                  detect-bin-dir)
          (only-in (submod "../libexec/rackup/runtime.rkt" for-testing)
                   hidden-runtime-invocation-prefix)
          (submod "../libexec/rackup/shell.rkt" for-testing))
@@ -291,7 +291,7 @@
                            (check-true (link-exists? (build-path (rackup-shims-dir) "racket")))
                            (check-true (link-exists? (build-path (rackup-shims-dir) "rackup")))
                            (define dispatcher-src (file->string (rackup-shim-dispatcher)))
-                           (check-true (string-contains? dispatcher-src "PLTHOME/.bin"))
+                           (check-true (string-contains? dispatcher-src "install_root/.bin"))
                            (check-true
                             (string-contains? dispatcher-src "resolved underlying executable"))
                            (check-true
@@ -343,12 +343,6 @@
           })
      (file-or-directory-permissions mzscheme-exe #o755)
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
-     (define env-vars (installed-toolchain-env-vars real-bin))
-     (check-equal? env-vars (list (cons "PLTHOME" (path->string plthome))))
-     (write-string-file (rackup-toolchain-env-file id)
-                        (string-append "#!/usr/bin/env bash\n"
-                                       "export PLTHOME="
-                                       (format "'~a'\n" (path->string plthome))))
      (define meta
        (hash 'id
              id
@@ -381,8 +375,7 @@
              'real-bin-dir
              (path->string real-bin)
              'env-vars
-             (for/list ([kv (in-list env-vars)])
-               (list (car kv) (cdr kv)))
+             '()
              'executables
              '("mzscheme")
              'installed-at
@@ -393,21 +386,23 @@
      (define mzscheme-out
        (capture-output
         (lambda () (system* (build-path (rackup-shims-dir) "mzscheme")))))
-     (check-true (string-contains? mzscheme-out (format "PLTHOME=~a" (path->string plthome))))))
+     ;; PLTHOME should NOT be set by the shim (it is not a Racket env var)
+     (check-true (string-contains? mzscheme-out "PLTHOME="))))
 
   (with-temp-rackup-home
    (lambda (tmp)
      (ensure-index!)
      (define id "release-103p1-bc-i386-linux-full")
      (define install-root (rackup-toolchain-install-dir id))
-     (define real-bin (build-path install-root "bin"))
+     ;; In a real PLT 103 installation, the layout is plt/bin/ and plt/.bin/.
+     ;; The dispatcher derives the install root from dirname(BIN_REAL) to find .bin/.
      (define plthome (build-path install-root "plt"))
+     (define real-bin (build-path plthome "bin"))
      (define legacy-bin (build-path plthome ".bin" "i386-linux"))
      (define archsys (build-path plthome "bin" "archsys"))
      (define fake-binfmt-dir (build-path tmp "binfmt"))
      (make-directory* real-bin)
      (make-directory* legacy-bin)
-     (make-directory* (build-path plthome "bin"))
      (make-directory* fake-binfmt-dir)
      (define racket-exe (build-path real-bin "racket"))
      (write-string-file racket-exe "#!/usr/bin/env bash\nexit 139\n")
@@ -422,9 +417,6 @@
      (file-or-directory-permissions (build-path legacy-bin "racket") #o755)
      (write-string-file (build-path fake-binfmt-dir "qemu-i386")
                         "enabled\ninterpreter /usr/bin/qemu-i386\n")
-     (write-string-file (rackup-toolchain-env-file id)
-                        (format "#!/usr/bin/env bash\nexport PLTHOME='~a'\n"
-                                (path->string plthome)))
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain!
@@ -580,18 +572,26 @@
 
      (define shim-racket (build-path (rackup-shims-dir) "racket"))
      (define old-pltaddon (getenv "PLTADDONDIR"))
+     (define old-plthome (getenv "PLTHOME"))
+     (define old-pltcollects (getenv "PLTCOLLECTS"))
      (void (putenv "PLTADDONDIR" ""))
+     (void (putenv "PLTHOME" ""))
+     (void (putenv "PLTCOLLECTS" ""))
      (define shim-out
        (capture-output (lambda () (system* shim-racket))))
      (void (if old-pltaddon
                (putenv "PLTADDONDIR" old-pltaddon)
                (putenv "PLTADDONDIR" "")))
-     ;; PLTHOME should be the checkout root, not the racket/ subdirectory
-     (check-true (regexp-match? (regexp (regexp-quote (format "PLTHOME=~a" (path->string src-root))))
-                                shim-out))
-     (check-true (regexp-match? (regexp (regexp-quote (format "PLTCOLLECTS=~a"
-                                                              (path->string collects-dir))))
-                                shim-out))
+     (void (if old-plthome
+               (putenv "PLTHOME" old-plthome)
+               (putenv "PLTHOME" "")))
+     (void (if old-pltcollects
+               (putenv "PLTCOLLECTS" old-pltcollects)
+               (putenv "PLTCOLLECTS" "")))
+     ;; PLTHOME and PLTCOLLECTS should NOT be set by the shim — they are not
+     ;; Racket env vars, and the binary finds its own collects.
+     (check-true (string-contains? shim-out "PLTHOME=\n"))
+     (check-true (string-contains? shim-out "PLTCOLLECTS=\n"))
      (check-true (regexp-match?
                   (regexp (regexp-quote (format "PLTADDONDIR=~a"
                                                 (path->string addon-dir))))
@@ -610,8 +610,8 @@
                                                       (path->string petite-boot))))
 
      (define activation (emit-shell-activation linked-id))
-     (check-true (string-contains? activation "export PLTHOME="))
-     (check-true (string-contains? activation "export PLTCOLLECTS="))
+     (check-false (string-contains? activation "export PLTHOME="))
+     (check-false (string-contains? activation "export PLTCOLLECTS="))
      (check-true (string-contains? activation (format "export PLTADDONDIR='~a'" (path->string addon-dir))))
      (expect (run-main (list "switch" "devsrc")) activation)
      @expect[(run-main '("prompt"))]{devsrc
@@ -626,8 +626,8 @@
 }
      (void (putenv "RACKUP_TOOLCHAIN" linked-id))
      (define deactivation (emit-shell-deactivation))
-     (check-true (string-contains? deactivation "unset PLTHOME"))
-     (check-true (string-contains? deactivation "unset PLTCOLLECTS"))
+     (check-false (string-contains? deactivation "unset PLTHOME"))
+     (check-false (string-contains? deactivation "unset PLTCOLLECTS"))
      (expect (run-main '("switch" "--unset")) deactivation)
      (void (putenv "RACKUP_TOOLCHAIN" ""))))
 
@@ -656,13 +656,11 @@
          (define raco-shim (build-path (rackup-shims-dir) "raco"))
          (define old-pltaddon (getenv "PLTADDONDIR"))
          (define old-pltcollects (getenv "PLTCOLLECTS"))
-         (define old-plthome (getenv "PLTHOME"))
          (define old-toolchain (getenv "RACKUP_TOOLCHAIN"))
          (dynamic-wind
            (lambda ()
              (putenv "PLTADDONDIR" "")
              (putenv "PLTCOLLECTS" "")
-             (putenv "PLTHOME" "")
              (putenv "RACKUP_TOOLCHAIN" ""))
            (lambda ()
              (define-values (proc stdout stdin stderr)
@@ -677,7 +675,6 @@
            (lambda ()
              (if old-pltaddon (putenv "PLTADDONDIR" old-pltaddon) (putenv "PLTADDONDIR" ""))
              (if old-pltcollects (putenv "PLTCOLLECTS" old-pltcollects) (putenv "PLTCOLLECTS" ""))
-             (if old-plthome (putenv "PLTHOME" old-plthome) (putenv "PLTHOME" ""))
              (if old-toolchain (putenv "RACKUP_TOOLCHAIN" old-toolchain)
                  (putenv "RACKUP_TOOLCHAIN" ""))))))))
 
@@ -737,14 +734,22 @@
      (check-not-false (member "scheme" (hash-ref linked-meta 'executables)))
      (check-not-false (member "petite" (hash-ref linked-meta 'executables)))
 
+     (define old-plthome (getenv "PLTHOME"))
+     (define old-pltcollects (getenv "PLTCOLLECTS"))
+     (void (putenv "PLTHOME" ""))
+     (void (putenv "PLTCOLLECTS" ""))
      (define shim-out
        (capture-output
         (lambda () (system* (build-path (rackup-shims-dir) "racket")))))
-     (check-true (regexp-match? (regexp (regexp-quote (format "PLTHOME=~a" (path->string plthome))))
-                                shim-out))
-     (check-true (regexp-match? (regexp (regexp-quote (format "PLTCOLLECTS=~a"
-                                                              (path->string collects-dir))))
-                                shim-out))
+     (void (if old-plthome
+               (putenv "PLTHOME" old-plthome)
+               (putenv "PLTHOME" "")))
+     (void (if old-pltcollects
+               (putenv "PLTCOLLECTS" old-pltcollects)
+               (putenv "PLTCOLLECTS" "")))
+     ;; PLTHOME and PLTCOLLECTS should NOT be set for linked toolchains
+     (check-true (string-contains? shim-out "PLTHOME=\n"))
+     (check-true (string-contains? shim-out "PLTCOLLECTS=\n"))
      (check-true (regexp-match? (regexp (regexp-quote (format "PLTADDONDIR=~a"
                                                               (path->string addon-dir))))
                                 shim-out))))
@@ -790,13 +795,11 @@
      (define current-collects
        (string-join (map path->string (current-library-collection-paths)) ":"))
      (define old-toolchain (getenv "RACKUP_TOOLCHAIN"))
-     (define old-plthome (getenv "PLTHOME"))
      (define old-pltcollects (getenv "PLTCOLLECTS"))
      (define old-pltaddondir (getenv "PLTADDONDIR"))
      (dynamic-wind
       (lambda ()
         (putenv "RACKUP_TOOLCHAIN" linked-id)
-        (putenv "PLTHOME" (path->string plthome))
         (putenv "PLTCOLLECTS"
                 (string-append (path->string poisoned-collects) ":" current-collects))
         (putenv "PLTADDONDIR" (path->string (build-path tmp "poisoned-addon"))))
@@ -807,9 +810,6 @@
         (if old-toolchain
             (putenv "RACKUP_TOOLCHAIN" old-toolchain)
             (putenv "RACKUP_TOOLCHAIN" ""))
-        (if old-plthome
-            (putenv "PLTHOME" old-plthome)
-            (putenv "PLTHOME" ""))
         (if old-pltcollects
             (putenv "PLTCOLLECTS" old-pltcollects)
             (putenv "PLTCOLLECTS" ""))
@@ -947,6 +947,8 @@
                                   (string-append (path->string fake-bin-dir)
                                                  ":"
                                                  (or (getenv "PATH") "/usr/bin:/bin"))))
+     ;; PLTHOME is not a Racket env var, so bin/rackup does not save/unset it.
+     ;; It passes through to the subprocess unchanged.
      (environment-variables-set! env #"PLTHOME" #"poison-plthome")
      (environment-variables-set! env #"PLTCOLLECTS" #"poison-collects")
      (environment-variables-set! env #"PLTADDONDIR" #"poison-addon")
@@ -966,8 +968,10 @@
      (check-true (string-suffix? (list-ref argv 4) "libexec/rackup-core.rkt"))
      (check-equal? (drop argv 5) '("current" "id"))
      (define env-lines (string-split (string-trim (file->string captured-env)) "\n"))
+     ;; PLTHOME passes through (not a Racket env var); PLTCOLLECTS and
+     ;; PLTADDONDIR are cleared by bin/rackup to protect its own runtime.
      (check-equal? env-lines
-                   '("PLTHOME="
+                   '("PLTHOME=poison-plthome"
                      "PLTCOLLECTS="
                      "PLTADDONDIR="))))
 

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -24,7 +24,7 @@
          "../libexec/rackup/util.rkt"
          "../libexec/rackup/versioning.rkt"
          (only-in (submod "../libexec/rackup/install.rkt" for-testing)
-                  detect-bin-dir)
+                  detect-bin-dir installed-toolchain-env-vars)
          (only-in (submod "../libexec/rackup/runtime.rkt" for-testing)
                   hidden-runtime-invocation-prefix)
          (submod "../libexec/rackup/shell.rkt" for-testing))
@@ -343,6 +343,14 @@
           })
      (file-or-directory-permissions mzscheme-exe #o755)
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
+     ;; Old PLT Scheme (parent dir named "plt") needs PLTHOME for its
+     ;; bin/mzscheme shell wrapper to find .bin/<archsys>/mzscheme.
+     (define env-vars (installed-toolchain-env-vars real-bin))
+     (check-equal? env-vars (list (cons "PLTHOME" (path->string plthome))))
+     (write-string-file (rackup-toolchain-env-file id)
+                        (string-append "#!/usr/bin/env bash\n"
+                                       "export PLTHOME="
+                                       (format "'~a'\n" (path->string plthome))))
      (define meta
        (hash 'id
              id
@@ -375,7 +383,8 @@
              'real-bin-dir
              (path->string real-bin)
              'env-vars
-             '()
+             (for/list ([kv (in-list env-vars)])
+               (list (car kv) (cdr kv)))
              'executables
              '("mzscheme")
              'installed-at
@@ -386,8 +395,8 @@
      (define mzscheme-out
        (capture-output
         (lambda () (system* (build-path (rackup-shims-dir) "mzscheme")))))
-     ;; PLTHOME should NOT be set by the shim (it is not a Racket env var)
-     (check-true (string-contains? mzscheme-out "PLTHOME="))))
+     ;; Old PLT Scheme needs PLTHOME for its bin/mzscheme wrapper
+     (check-true (string-contains? mzscheme-out (format "PLTHOME=~a" (path->string plthome))))))
 
   (with-temp-rackup-home
    (lambda (tmp)

--- a/test/vm/native-i386-firstboot.sh
+++ b/test/vm/native-i386-firstboot.sh
@@ -175,9 +175,9 @@ if [ "$MODE" = debug ]; then
   # shellcheck disable=SC2016
   run_case_sh direct-no-aslr 'exec setarch i386 -R "$1"' "$REAL_BIN"
   # shellcheck disable=SC2016
-  run_case_sh direct-min-env 'exec env -i HOME=/root PATH=/usr/bin:/bin PLTHOME="$2" PLTADDONDIR="$3" "$1"' "$REAL_BIN" "$PLTHOME" "$PLTADDONDIR"
+  run_case_sh direct-min-env 'exec env -i HOME=/root PATH=/usr/bin:/bin PLTADDONDIR="$2" "$1"' "$REAL_BIN" "$PLTADDONDIR"
   # shellcheck disable=SC2016
-  run_case_sh direct-no-aslr-min-env 'exec env -i HOME=/root PATH=/usr/bin:/bin PLTHOME="$2" PLTADDONDIR="$3" setarch i386 -R "$1"' "$REAL_BIN" "$PLTHOME" "$PLTADDONDIR"
+  run_case_sh direct-no-aslr-min-env 'exec env -i HOME=/root PATH=/usr/bin:/bin PLTADDONDIR="$2" setarch i386 -R "$1"' "$REAL_BIN" "$PLTADDONDIR"
 
   set +e
   strace -f -o "$OUTPUT_DIR/mzscheme.strace" "$REAL_BIN" <"$OUTPUT_DIR/mzscheme.input" >"$OUTPUT_DIR/mzscheme-strace.stdout" 2>"$OUTPUT_DIR/mzscheme-strace.stderr"


### PR DESCRIPTION
## Summary

- Stop setting `PLTHOME` and `PLTCOLLECTS` in toolchain env files — neither is a Racket env var (`PLTHOME` is a plt-bin convention, `PLTCOLLECTS` was only compensating for `PLTHOME`)
- User-set `PLTCOLLECTS` now passes through to the toolchain's Racket, so users can have collection directories available regardless of active toolchain
- Dispatcher's legacy `.bin` lookup for old PLT Scheme derives install root from `BIN_REAL` instead of `$PLTHOME`
- Remove `PLTHOME` from `bin/rackup`'s save/unset loop since it is not a Racket env var

cc @mfelleisen

## Test plan

- [x] All 240 unit tests pass
- [ ] Docker E2E bootstrap test
- [ ] Verify user-set `PLTCOLLECTS` passes through to both linked and installed toolchains
- [ ] Verify old PLT Scheme installs still find their collections