### PR TITLE
Add quick start guides for different user personas

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -39,7 +39,9 @@ jobs:
           xargs shfmt -d -i 2 -ci < /tmp/shell-scripts.txt
 
       - name: Install checkbashisms
-        run: sudo apt-get install -y -qq devscripts
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq devscripts
 
       - name: install.sh smoke (self-upgrade code path)
         shell: bash

--- a/docs/rackup.scrbl
+++ b/docs/rackup.scrbl
@@ -542,6 +542,142 @@ Print rackup version information (git commit hash and date).
 @shell-block{rackup version}
 
 @; ════════════════════════════════════════════════════════════════════
+@;  QUICK START GUIDES
+@; ════════════════════════════════════════════════════════════════════
+
+@section[#:tag "quick-start" #:style 'unnumbered]{Quick start guides}
+
+Pick the guide that matches your situation.
+
+@subsection[#:tag "qs-new-user" #:style sub-style]{New to Racket}
+
+If you have never used Racket before, start here.
+
+@shell-block|{
+# 1. Install rackup
+curl -fsSL https://samth.github.io/rackup/install.sh | sh
+
+# 2. Install the latest stable Racket release
+rackup install stable
+
+# 3. Set up your shell so "racket" and "raco" are on PATH
+rackup init --shell bash   # or zsh
+
+# 4. Start a new shell (or source your rc file), then:
+racket                     # interactive REPL
+raco pkg install gregor    # install a package
+}|
+
+@subsection[#:tag "qs-existing-user" #:style sub-style]{Existing Racket user}
+
+You already have Racket installed and want to manage multiple versions.
+
+@shell-block|{
+# 1. Install rackup
+curl -fsSL https://samth.github.io/rackup/install.sh | sh
+rackup init --shell bash   # or zsh
+
+# 2. Install versions you need
+rackup install 8.18
+rackup install stable
+
+# 3. Set a global default
+rackup default stable
+
+# 4. Switch in the current shell when needed
+rackup switch 8.18
+racket --version           # → 8.18
+rackup switch stable
+racket --version           # → latest stable
+}|
+
+Your existing system Racket is not affected.  Once the shims directory
+is on your @tt{PATH}, the shimmed @tt{racket} takes precedence.  To
+go back to your system Racket, run @tt{rackup default clear} and
+remove the rackup init block from your shell rc.
+
+@subsection[#:tag "qs-racket-dev" #:style sub-style]{Racket developer (source builds)}
+
+You build Racket from source and want to switch between your
+development tree and release builds.
+
+@shell-block|{
+# 1. Install rackup
+curl -fsSL https://samth.github.io/rackup/install.sh | sh
+rackup init --shell bash   # or zsh
+
+# 2. Link your local source tree
+rackup link dev ~/src/racket
+
+# 3. Optionally install a release for comparison
+rackup install stable
+
+# 4. Switch between them
+rackup default dev
+rackup switch stable       # test against a release
+rackup switch dev          # back to your build
+}|
+
+The linked directory is not copied — rackup creates a symlink and
+metadata so shims and @tt{rackup switch} work with it.  After
+editing your source tree, the changes are visible immediately
+(no re-link needed).
+
+If you previously used
+@hyperlink["https://github.com/takikawa/racket-dev-goodies"]{racket-dev-goodies},
+including the @tt{plt-bin} shell script, see @secref["migration"] for migration steps.
+
+@subsection[#:tag "qs-pkg-dev" #:style sub-style]{Package developer}
+
+You develop Racket packages and need to test against multiple Racket
+versions.
+
+@shell-block|{
+# Install the versions you want to test against
+rackup install stable
+rackup install pre-release
+rackup install 8.15
+
+# Run your test suite under each version
+rackup run stable -- raco test .
+rackup run pre-release -- raco test .
+rackup run 8.15 -- raco test .
+}|
+
+@tt{rackup run} sets @tt{PLTADDONDIR} and @tt{PATH}
+for the subprocess only — your shell's active toolchain is unchanged.
+Each toolchain gets its own addon directory, so installed packages
+don't collide between versions.
+
+@subsection[#:tag "qs-ci" #:style sub-style]{CI / Docker / automation}
+
+Use non-interactive mode for scripts, CI pipelines, and containers.
+
+@shell-block|{
+# Non-interactive install (no prompts)
+curl -fsSL https://samth.github.io/rackup/install.sh | sh -s -- -y
+
+# Install a toolchain quietly
+rackup install stable --quiet
+
+# Run commands without shell integration
+rackup run stable -- raco test .
+rackup run stable -- raco pkg install --auto gregor
+}|
+
+In a Dockerfile:
+
+@shell-block|{
+RUN curl -fsSL https://samth.github.io/rackup/install.sh | sh -s -- -y \
+ && ~/.rackup/bin/rackup install stable --quiet
+ENV PATH="/root/.rackup/shims:/root/.rackup/bin:${PATH}"
+}|
+
+For scripting, @tt{rackup list --ids} prints one toolchain ID per
+line and @tt{rackup current id} prints just the active ID — both are
+easy to parse.
+
+@; ════════════════════════════════════════════════════════════════════
 @;  GUIDE SECTIONS
 @; ════════════════════════════════════════════════════════════════════
 

--- a/pages/site.rkt
+++ b/pages/site.rkt
@@ -242,6 +242,31 @@
               margin-bottom: 0.3rem;
             }
 
+            /* Persona quick-start cards */
+            .rackup-personas {
+              display: grid;
+              gap: 1.5rem;
+              grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+              margin-top: 1rem;
+            }
+            .rackup-persona {
+              background: #fafafa;
+              border: 1px solid #e0e0e0;
+              border-radius: 8px;
+              padding: 1.2rem 1.2rem 0.8rem;
+            }
+            .rackup-persona h3 {
+              color: #0679a7;
+              font-size: 1.05rem;
+              font-weight: 600;
+              margin: 0 0 0.3rem;
+            }
+            .rackup-persona > p {
+              color: #555;
+              font-size: 0.95rem;
+              margin: 0 0 0.8rem;
+            }
+
             /* Command reference */
             .rackup-cmd-table {
               border: none !important;
@@ -363,6 +388,37 @@ sh install.sh && rm install.sh})
               toolchain you install becomes the default automatically.
             }}
           @div{@(shell-block "workflow-cmd" "$ rackup install stable\n$ rackup install pre-release\n$ rackup default stable\n$ racket -e '(displayln (version))'\n$ raco pkg install gregor")}}}
+
+      @div[class: "rackup-section"]{
+        @h2{Quick start by use case}
+        @p{
+          Pick the guide that matches your situation.
+        }
+        @div[class: "rackup-personas"]{
+          @div[class: "rackup-persona"]{
+            @h3{New to Racket}
+            @p{Get up and running from scratch.}
+            @(shell-block "persona-new" "curl -fsSL https://samth.github.io/rackup/install.sh | sh\nrackup install stable\nrackup init --shell bash   # or zsh\nracket")
+          }
+          @div[class: "rackup-persona"]{
+            @h3{Existing Racket user}
+            @p{Manage multiple Racket versions side by side.}
+            @(shell-block "persona-existing" "curl -fsSL https://samth.github.io/rackup/install.sh | sh\nrackup install 8.18\nrackup install stable\nrackup default stable\nrackup switch 8.18          # switch in current shell")
+          }
+          @div[class: "rackup-persona"]{
+            @h3{Racket developer (source builds)}
+            @p{Link your local source tree alongside release builds.}
+            @(shell-block "persona-dev" "curl -fsSL https://samth.github.io/rackup/install.sh | sh\nrackup link dev ~/src/racket\nrackup install stable\nrackup default dev\nrackup switch stable         # try a release build\nrackup switch dev            # back to your source tree")
+          }
+          @div[class: "rackup-persona"]{
+            @h3{Package developer}
+            @p{Test your package across multiple Racket versions.}
+            @(shell-block "persona-pkg" "rackup install stable\nrackup install pre-release\nrackup install 8.15\nrackup run stable -- raco test .\nrackup run pre-release -- raco test .\nrackup run 8.15 -- raco test .")
+          }
+          @div[class: "rackup-persona"]{
+            @h3{CI / Docker / automation}
+            @p{Non-interactive setup for scripts and containers.}
+            @(shell-block "persona-ci" "curl -fsSL https://samth.github.io/rackup/install.sh | sh -s -- -y\nrackup install stable --quiet\nrackup run stable -- raco test .")}}}
 
       @div[class: "rackup-section"]{
         @h2{Commands}


### PR DESCRIPTION
## Summary
This PR adds comprehensive quick start guides to the rackup documentation, tailored to different user personas and use cases. The guides are presented both in the main documentation and on the website landing page.

## Key Changes

- **Documentation (`docs/rackup.scrbl`)**: Added a new "Quick start guides" section with five subsections covering:
  - New to Racket: Installation and basic setup from scratch
  - Existing Racket user: Managing multiple Racket versions
  - Racket developer (source builds): Linking and switching between development and release builds
  - Package developer: Testing across multiple Racket versions
  - CI / Docker / automation: Non-interactive setup for scripts and containers

- **Website (`pages/site.rkt`)**: 
  - Added CSS styling for persona cards (`.rackup-personas` and `.rackup-persona` classes) with a responsive grid layout
  - Added a "Quick start by use case" section on the landing page featuring five persona cards with condensed command examples
  - Each card includes a title, description, and relevant shell commands

## Implementation Details

- The documentation guides provide detailed explanations and context for each use case
- The website cards provide quick visual access to the most common workflows with minimal command examples
- Both use consistent messaging and command sequences to reinforce key concepts
- The responsive grid layout ensures the persona cards work well on different screen sizes
- Styling uses a light background (#fafafa) with subtle borders to distinguish cards from the main content

https://claude.ai/code/session_014FunN2YwFK3qkCyjy43CZE