### PR TITLE
Set per-toolchain PLTCOMPILEDROOTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,15 @@ workflows (`.github/workflows/`), and install scripts
 (`scripts/install.sh`) for the corresponding generation step. If it
 doesn't exist, add it in the same commit.
 
+## Testing Racket behavior
+
+When investigating how Racket handles environment variables
+(`PLTADDONDIR`, `PLTCOMPILEDROOTS`, etc.), always use the actual
+Racket binary (`/home/samth/sw/plt/racket/bin/racket` or similar),
+not `racket` through the rackup shim. The shim dispatcher saves,
+unsets, and re-sets Racket env vars, so testing through the shim
+gives misleading results about Racket's native behavior.
+
 ## Code ownership
 
 We own the entire project. There is no public API. Feel free to change any module's exports, signatures, or internal structure as needed — no backwards-compatibility workarounds required.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -133,26 +133,50 @@ Several inputs from the environment are validated before use:
 
 When `bin/rackup` starts, it saves any user-set Racket environment variables (`PLTCOLLECTS`, `PLTADDONDIR`, `PLTCOMPILEDROOTS`, `PLTUSERHOME`, `RACKET_XPATCH`, `PLT_COMPILED_FILE_CHECK`) as `_RACKUP_ORIG_*` and then unsets the originals. This prevents the user's Racket environment from interfering with rackup's own runtime (whether hidden runtime or embedded exe). `PLTHOME` is not included because it is not a Racket environment variable (it is a convention from the `plt-bin` script in `racket-dev-goodies`).
 
-When `rackup run` spawns a subprocess, `restore-saved-racket-env-vars!` in `util.rkt` first restores the user's original Racket environment variables from the `_RACKUP_ORIG_*` copies. Then `cmd-run` overlays the target toolchain's managed environment variables on top (currently only `PLTADDONDIR`). This means a user-set `PLTCOLLECTS` passes through to the toolchain's Racket, allowing users to add collection directories that are available regardless of which toolchain is active.
+When `rackup run` spawns a subprocess, `restore-saved-racket-env-vars!` in `util.rkt` first restores the user's original Racket environment variables from the `_RACKUP_ORIG_*` copies. Then `cmd-run` overlays the target toolchain's managed environment variables on top (`PLTADDONDIR`, and `PLTCOMPILEDROOTS` unless the user has set their own). This means a user-set `PLTCOLLECTS` passes through to the toolchain's Racket, allowing users to add collection directories that are available regardless of which toolchain is active.
 
 ## Per-toolchain env.sh
 
 The shim dispatcher sources a per-toolchain `env.sh` file if present. For linked (local) toolchains, the env file is regenerated on every `reshim!` call by `regenerate-env-files!` in `shims.rkt`, because the source tree layout may change. If a local toolchain has no derivable env vars (e.g., the source root cannot be located), the env file is deleted rather than written empty. Installed (release/snapshot) toolchains do not have env files.
 
-The env file exports only `PLTADDONDIR` when a value can be computed. Neither `PLTHOME` nor `PLTCOLLECTS` is set — the Racket binary finds its own collections via compiled-in relative paths, and `PLTHOME` is not a Racket environment variable. The one exception is old PLT Scheme installations (version <= 4.x) where the parent directory is named `plt`: these set `PLTHOME` because PLT Scheme's `bin/mzscheme` shell wrapper uses it to locate the real binary under `.bin/<archsys>/`. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`).
+The env file exports all variables unconditionally (`PLTADDONDIR`, `PLTCOMPILEDROOTS`). The shim dispatcher sources env.sh per-invocation, so these are scoped to each subprocess — they do not leak into the user's shell. Neither `PLTHOME` nor `PLTCOLLECTS` is set — the Racket binary finds its own collections via compiled-in relative paths, and `PLTHOME` is not a Racket environment variable. The one exception is old PLT Scheme installations (version <= 4.x) where the parent directory is named `plt`: these set `PLTHOME` because PLT Scheme's `bin/mzscheme` shell wrapper uses it to locate the real binary under `.bin/<archsys>/`. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`).
 
-## Post-self-upgrade reshim
+## Per-toolchain PLTCOMPILEDROOTS
 
-`cmd-self-upgrade` invokes `rackup reshim` in a subprocess after a successful update, so the freshly-installed rackup code drives the reshim. Running reshim in-process would use the old in-memory code and miss any new migration logic introduced by the upgrade.
+Different Racket versions (and CS vs BC) produce incompatible `.zo` bytecode. To prevent cross-version contamination in `compiled/` directories under user source trees, rackup sets `PLTCOMPILEDROOTS` per toolchain so each version+variant writes compiled output to its own subdirectory while preserving access to the toolchain's existing compiled files.
+
+### How the value is constructed
+
+At toolchain install or link time, `compiled-roots-value` in `state.rkt` constructs a colon-separated PLTCOMPILEDROOTS string:
+
+1. The first entry is `compiled/<version>-<variant>` (e.g., `compiled/9.1-cs`), which is where new `.zo` files are written.
+2. The remaining entries are the toolchain's existing `compiled-file-roots`, read from its `config.rktd` by `read-toolchain-compiled-file-roots`. This preserves the toolchain's native compiled-file layout:
+   - **In-place installs** (rackup's default): existing roots = `(same)`, serialized as `.` → `compiled/9.1-cs:.`
+   - **FHS installs** (e.g., setup-racket on CI): existing roots include an absolute reroot path → `compiled/9.1-cs:/usr/lib/racket/compiled:.`
+3. `.` (equivalent to `'same`) is always included in the fallbacks so that user code's `compiled/` directories are found regardless of install layout.
+
+The `'same` symbol in `current-compiled-file-roots` cannot be spelled directly in PLTCOMPILEDROOTS because `path-list-string->path-list` converts all entries to path objects. However, `.` is a relative path that `(build-path dir ".")` resolves to `dir` itself, which is functionally equivalent.
+
+For linked toolchains where version or variant cannot be probed, PLTCOMPILEDROOTS is omitted. The value flows through the existing `env-vars` metadata pipeline: `write-env-file!`/`write-toolchain-env-file!` emits an unconditional export in env.sh (sourced per-invocation by the shim dispatcher), and `cmd-run` in `main.rkt` preserves a user-restored value before overlaying toolchain env vars. Racket-specific env vars are **not** exported into the user's shell by `rackup switch` — only `RACKUP_TOOLCHAIN` and `PATH` are set in the shell, to avoid leaking into non-rackup commands like `make install` in a source checkout.
+
+### Migration for existing installs
+
+Toolchains installed by an older rackup do not have PLTCOMPILEDROOTS in their `meta.rktd`. `regenerate-env-files!` in `shims.rkt` backfills it: on every `reshim!` call (which runs as part of `commit-state-change!` for any state-modifying command), each installed toolchain's metadata is checked, and if it lacks PLTCOMPILEDROOTS but the version+variant yield a value, the entry is added to `meta.rktd` and `env.sh` is rewritten. The backfill is idempotent — subsequent reshims see the entry and do nothing. Users only need to run any state-changing command (e.g., `rackup reshim`, `rackup install`, `rackup upgrade`) after upgrading rackup to pick up the new PLTCOMPILEDROOTS for existing toolchains.
+
+### Cleaning up on removal
+
+`rackup remove <toolchain> --clean-compiled` removes `compiled/<key>/` subdirectories from user package source trees before removing the toolchain. The toolchain's install directory and addon directory are fully deleted by `remove-toolchain!`, so those don't need explicit cleanup — this flag targets the directories that persist afterwards: user-scope catalog packages (which live under the addon dir) and linked packages (`raco pkg install --link <dir>`) whose source trees are anywhere on disk.
+
+The implementation runs the toolchain's own `racket -e` with a small program that uses `pkg/lib`'s `installed-pkg-table` and `pkg-directory` to print the absolute source directory of every user-scope package, then walks each directory to find and delete `compiled/<key>/` subdirectories.
 
 ## Shell integration
 
 `rackup init` writes a managed block into `~/.bashrc` or `~/.zshrc` delimited by marker comments (`# >>> rackup initialize >>>`). The managed block:
 
 1. Prepends `~/.rackup/shims` to `PATH`.
-2. Defines a `rackup()` shell function that intercepts `rackup switch` and `rackup shell` commands, evals the output (shell code that sets environment variables), and delegates everything else to the real `rackup` binary.
+2. Defines a `rackup()` shell function that intercepts `rackup switch` and `rackup shell` commands, evals the output (shell code that sets `RACKUP_TOOLCHAIN`), and delegates everything else to the real `rackup` binary.
 
-The shell function is necessary because a child process cannot modify its parent's environment. `rackup switch stable` emits shell code like `export RACKUP_TOOLCHAIN=release-9.1-cs-x86_64-linux-full; export PLTHOME=...`, and the shell function evals it in the current shell.
+The shell function is necessary because a child process cannot modify its parent's environment. `rackup switch stable` emits shell code like `export RACKUP_TOOLCHAIN=release-9.1-cs-x86_64-linux-full`, and the shell function evals it in the current shell. Racket-specific env vars (`PLTADDONDIR`, `PLTCOMPILEDROOTS`, `PLTHOME`) are not exported into the shell — they are set internally by the shim dispatcher via env.sh, scoped to each subprocess invocation. This prevents them from leaking into non-rackup commands.
 
 Tab completion scripts for bash and zsh are generated by `shell.rkt` and written to `~/.rackup/shell/rackup.{bash,zsh}`. The completion functions enumerate installed toolchains by listing the `~/.rackup/toolchains/` directory.
 

--- a/docs/rackup.scrbl
+++ b/docs/rackup.scrbl
@@ -308,10 +308,26 @@ directory.  For linked toolchains, only the rackup metadata and symlink
 are removed; the original source tree is untouched.  Shims are rebuilt
 automatically afterward.
 
-@shell-block{rackup remove <toolchain>}
+@shell-block{rackup remove [--clean-compiled] <toolchain>}
 
 Also removes orphan/partial toolchain directories that were left behind
 by interrupted installs.
+
+@subsection[#:tag "remove-flags" #:style sub-style]{Flags}
+
+@opt-table[
+  @list[@exec{--clean-compiled}
+        @elem{Before removing the toolchain, delete any
+              @tt{compiled/<version>-<variant>/} subdirectories found in
+              the source trees of user-scope and linked packages.  This
+              cleans up stale @tt{.zo} files written under rackup's
+              per-toolchain @tt{PLTCOMPILEDROOTS} (see
+              @secref["environment-variables"]) that would otherwise persist after
+              the toolchain is removed.  Requires the toolchain's
+              @tt{racket} to be operational, since package source
+              directories are enumerated via the toolchain's own
+              @tt{pkg/lib}.}]
+]
 
 @; ────────────────────────────────────────────────────────────────────
 
@@ -754,12 +770,19 @@ can remove it cleanly.
         "Override the active toolchain for the current shell session. Set by rackup switch; can also be set manually."]
 ]
 
-@subsection[#:style sub-style]{Set by rackup when activating a toolchain}
+@subsection[#:style sub-style]{Set by rackup switch (in user's shell)}
 
 @opt-table[
-  @list[@tt{PLTHOME}     "Root of the active Racket installation."]
-  @list[@tt{PLTADDONDIR} "Per-toolchain addon directory (packages, compiled files)."]
-  @list[@tt{PATH}        "Prepended with the shims directory."]
+  @list[@tt{RACKUP_TOOLCHAIN}  "The active toolchain ID."]
+  @list[@tt{PATH}              "Prepended with the shims directory."]
+]
+
+@subsection[#:style sub-style]{Set internally by the shim dispatcher (per invocation)}
+
+@opt-table[
+  @list[@tt{PLTHOME}           "Root of the active Racket installation (old PLT Scheme only)."]
+  @list[@tt{PLTADDONDIR}       "Per-toolchain addon directory (packages, compiled files)."]
+  @list[@tt{PLTCOMPILEDROOTS}  @elem{Version-variant-specific compiled root (e.g., @tt{compiled/9.1-cs:.}) so different toolchains do not share @tt{.zo} files.}]
 ]
 
 Rackup saves and restores any user-set values of @tt{PLTHOME},
@@ -767,6 +790,104 @@ Rackup saves and restores any user-set values of @tt{PLTHOME},
 @tt{PLTUSERHOME}, @tt{RACKET_XPATCH}, and @tt{PLT_COMPILED_FILE_CHECK}
 before overriding them, so @tt{rackup run} passes through your original
 settings to the subprocess.
+
+@; ────────────────────────────────────────────────────────────────────
+
+@section[#:tag "compiled-files" #:style 'unnumbered]{Per-toolchain compiled files}
+
+Different Racket versions, and the Chez-based (@tt{cs}) and bytecode
+(@tt{bc}) VMs within a single version, produce incompatible @tt{.zo}
+files.  Without per-toolchain separation, compiling a collection under
+Racket 9.1-cs and then switching to 8.18-bc would leave behind
+@tt{.zo} files that the new toolchain cannot load, forcing a manual
+@tt{raco setup} or a @tt{rm -rf compiled/} dance.
+
+Rackup avoids this by setting @tt{PLTCOMPILEDROOTS} per toolchain so
+each version+variant writes its compiled output to its own
+subdirectory, while preserving the toolchain's existing compiled-file
+roots so pre-existing @tt{.zo} files are still found.
+
+At install or link time, rackup reads the toolchain's
+@tt{config.rktd} to discover its existing @tt{compiled-file-roots}
+and constructs a @tt{PLTCOMPILEDROOTS} value that prepends the
+versioned root:
+
+@shell-block|{
+# In-place layout (rackup's default --in-place installs):
+PLTCOMPILEDROOTS=compiled/9.1-cs:.
+
+# FHS layout (e.g., system-packaged Racket):
+PLTCOMPILEDROOTS=compiled/9.1-cs:/usr/lib/racket/compiled:.
+}|
+
+The first entry (@tt{compiled/9.1-cs}) is where new @tt{.zo} files
+are written.  The remaining entries are the toolchain's native
+compiled-file roots (preserved from its @tt{config.rktd}), plus
+@tt{.} which resolves to the source directory itself so that user
+code's @tt{compiled/} directories are always found.
+
+For example, if you install Racket from a full installer (which ships
+with pre-compiled @tt{.zo} files) and manage it via rackup, those
+pre-compiled files are found through the fallback roots without
+recompiling.  New compilations go into @tt{compiled/9.1-cs/}.
+
+@subsection[#:style sub-style]{How the key is chosen}
+
+The subdirectory name is @tt{<resolved-version>-<variant>}.  Full and
+minimal distributions of the same version+variant share a directory
+(they run the same compiler, so their @tt{.zo} files are compatible),
+while CS and BC are separated because their bytecode formats are
+incompatible.  Snapshots and development builds get their own keys
+based on the probed version (e.g., @tt{9.1.0.3-cs}), which naturally
+separates them from release builds.
+
+For linked toolchains whose version or variant cannot be probed,
+@tt{PLTCOMPILEDROOTS} is left unset so the toolchain uses the default
+@tt{compiled/} directory.
+
+Toolchains installed by an older version of rackup are migrated
+automatically: the next time any rackup state-changing command runs
+(e.g., @tt{rackup reshim}, @tt{rackup install}, @tt{rackup upgrade}),
+any installed toolchain whose @tt{meta.rktd} predates per-toolchain
+@tt{PLTCOMPILEDROOTS} has the entry backfilled in place.  No
+reinstallation is required.
+
+@subsection[#:style sub-style]{Environment scoping}
+
+Racket-specific env vars (@tt{PLTCOMPILEDROOTS}, @tt{PLTADDONDIR},
+@tt{PLTHOME}) are set internally by the shim dispatcher via
+per-toolchain @tt{env.sh} files, scoped to each subprocess
+invocation.  @tt{rackup switch} only sets @tt{RACKUP_TOOLCHAIN} and
+@tt{PATH} in the user's shell.  This prevents rackup's env vars from
+leaking into non-rackup commands (e.g., @tt{make install} in a
+Racket source checkout).
+
+For @tt{rackup run}, if the user had @tt{PLTCOMPILEDROOTS} set before
+invoking rackup, the saved value is restored and takes precedence
+over the toolchain's default.
+
+@subsection[#:style sub-style]{Cleaning up}
+
+New @tt{.zo} files written by a toolchain can end up outside
+rackup's own state directories — specifically, in the source trees of
+packages installed with @tt{raco pkg install --link}, or in any
+directory where you run @tt{raco make} manually.  When you
+@tt{rackup remove} a toolchain, the toolchain's own @tt{collects/}
+and addon directory are deleted, but these user directories are not.
+
+Passing @tt{--clean-compiled} to @tt{rackup remove} walks the source
+directories of every user-scope package (catalog and linked) and
+removes any @tt{compiled/<key>/} subdirectories before the toolchain
+itself is removed:
+
+@shell-block{rackup remove 9.1 --clean-compiled}
+
+This enumerates packages via the toolchain's own @tt{racket} and
+@tt{pkg/lib}, so it needs the outgoing toolchain to still be
+operational.  Package source directories outside of rackup's
+knowledge (projects you work on directly, collections under
+@tt{raco link}, etc.) are not touched — you can clean those up
+manually with @tt{rm -rf compiled/9.1-cs} in each directory.
 
 @; ────────────────────────────────────────────────────────────────────
 

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -518,7 +518,7 @@
               'pkgs-dir
               (and (directory-exists? pkgs) (path-complete-string pkgs)))])]))
 
-(define (local-layout-env-vars layout [addon-dir #f] [version #f] [variant #f])
+(define (local-layout-env-vars layout [addon-dir #f] [version #f] [variant #f] [local-name #f])
   (define source-root (hash-ref layout 'source-root #f))
   ;; For source checkouts, default PLTADDONDIR to <checkout>/add-on
   ;; (matching the plt-bin convention).
@@ -537,7 +537,7 @@
         '(same)))
   (define compiled-roots-entry
     (cond
-      [(compiled-roots-value version variant existing-roots)
+      [(compiled-roots-value version variant existing-roots local-name)
        =>
        (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
       [else null]))
@@ -808,7 +808,7 @@
              base-env-vars))
        (define-values (version* variant* addon-dir*)
          (probe-local-racket-version+variant+addon-dir (path->string* real-bin-dir) probe-env-vars))
-       (define env-vars (local-layout-env-vars layout addon-dir* version* variant*))
+       (define env-vars (local-layout-env-vars layout addon-dir* version* variant* name))
        (make-bin-overlay! id real-bin-dir extra-exes)
        (maybe-wrap-local-chez-extra-executables! id extra-exes layout)
        (if (pair? env-vars)
@@ -1066,9 +1066,14 @@
   (unless (hash? meta)
     (install-warn "Cannot clean compiled dirs: missing metadata for ~a" id)
     (set! meta (hash)))
+  (define local-name
+    (and (eq? (hash-ref meta 'kind #f) 'local)
+         (hash-ref meta 'requested-spec #f)))
   (define key-value
     (compiled-roots-value (hash-ref meta 'resolved-version #f)
-                          (hash-ref meta 'variant #f)))
+                          (hash-ref meta 'variant #f)
+                          '(same)
+                          local-name))
   (cond
     [(not key-value)
      (install-warn

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -322,7 +322,7 @@
                    "# rackup managed toolchain environment\n"
                    (apply string-append
                           (for/list ([kv (in-list env-vars)])
-                            (format "export ~a=~a\n" (car kv) (sh-single-quote (cdr kv)))))))
+                            (env-var-export-line (car kv) (cdr kv))))))
   (write-string-file p body)
   (file-or-directory-permissions p #o644)
   p)
@@ -518,7 +518,7 @@
               'pkgs-dir
               (and (directory-exists? pkgs) (path-complete-string pkgs)))])]))
 
-(define (local-layout-env-vars layout [addon-dir #f])
+(define (local-layout-env-vars layout [addon-dir #f] [version #f] [variant #f])
   (define source-root (hash-ref layout 'source-root #f))
   ;; For source checkouts, default PLTADDONDIR to <checkout>/add-on
   ;; (matching the plt-bin convention).
@@ -526,31 +526,51 @@
     (or addon-dir
         (and source-root
              (path->string* (build-path (string->path source-root) "add-on")))))
-  (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
-      (list (cons "PLTADDONDIR" effective-addon-dir))
-      null))
+  (define addon-entry
+    (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
+        (list (cons "PLTADDONDIR" effective-addon-dir))
+        null))
+  (define bin-dir-str (hash-ref layout 'bin-dir #f))
+  (define existing-roots
+    (if bin-dir-str
+        (read-toolchain-compiled-file-roots (string->path bin-dir-str))
+        '(same)))
+  (define compiled-roots-entry
+    (cond
+      [(compiled-roots-value version variant existing-roots)
+       =>
+       (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
+      [else null]))
+  (append addon-entry compiled-roots-entry))
 
 (define (probe-local-racket-version+variant+addon-dir bin-dir env-vars)
   (define racket-exe (build-path (string->path bin-dir) "racket"))
-  (define version-out (capture-program-output #:env env-vars racket-exe "-e" "(display (version))"))
-  (define variant-out
+  ;; Combine all three queries into a single racket invocation to avoid
+  ;; paying startup cost three times.
+  (define combined-out
     (capture-program-output
      #:env env-vars
      racket-exe
      "-e"
-     "(display (let ([v (system-type 'vm)]) (if (symbol? v) (symbol->string v) (format \"~a\" v))))"))
-  (define addon-out
-    (capture-program-output
-     #:env env-vars
-     racket-exe
-     "-e"
-     "(display (find-system-path 'addon-dir))"))
+     (string-append
+      "(displayln (version))"
+      "(displayln (let ([v (system-type 'vm)])"
+      "  (if (symbol? v) (symbol->string v) (format \"~a\" v))))"
+      "(display (find-system-path 'addon-dir))")))
   (define (normalize-vm-name s)
     (and s (not (string-blank? s))
          (match (string-downcase s)
            ["chez-scheme" "cs"]
            ["racket" "bc"]
            [v v])))
+  (define-values (version-out variant-out addon-out)
+    (if combined-out
+        (let ([lines (string-split combined-out "\n")])
+          (if (>= (length lines) 3)
+              (values (first lines) (second lines)
+                      (string-join (drop lines 2) "\n"))
+              (values #f #f #f)))
+        (values #f #f #f)))
   (values (and version-out (not (string-blank? version-out)) version-out)
           (normalize-vm-name variant-out)
           (and addon-out (not (string-blank? addon-out)) addon-out)))
@@ -558,7 +578,7 @@
 ;; Old PLT Scheme installations (version <= 4.x) have a shell wrapper at
 ;; plt/bin/mzscheme that uses $PLTHOME to locate the real binary under
 ;; plt/.bin/<archsys>/. Set PLTHOME for these so the wrapper works.
-(define (installed-toolchain-env-vars real-bin-dir)
+(define (installed-toolchain-env-vars real-bin-dir [request #f])
   (define plthome (maybe-parent real-bin-dir))
   (define-values (plthome-base plthome-leaf _plthome-dir?)
     (if plthome
@@ -568,10 +588,21 @@
     (and (path? plthome-leaf) (path->string plthome-leaf)))
   (define plthome-normalized
     (and plthome-base (path? plthome-leaf) (build-path plthome-base plthome-leaf)))
-  (cond
-    [(and plthome-normalized (equal? plthome-name "plt"))
-     (list (cons "PLTHOME" (path->string* plthome-normalized)))]
-    [else null]))
+  (define plthome-entry
+    (cond
+      [(and plthome-normalized (equal? plthome-name "plt"))
+       (list (cons "PLTHOME" (path->string* plthome-normalized)))]
+      [else null]))
+  (define compiled-roots-entry
+    (cond
+      [(and (hash? request)
+            (compiled-roots-value (hash-ref request 'resolved-version #f)
+                                  (hash-ref request 'variant #f)
+                                  (read-toolchain-compiled-file-roots real-bin-dir)))
+       =>
+       (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
+      [else null]))
+  (append plthome-entry compiled-roots-entry))
 
 (define (toolchain-meta request id real-bin-dir executables [env-vars null])
   (hash 'id
@@ -767,9 +798,17 @@
        (make-directory* tc-dir)
        (define extra-exes (find-local-chez-extra-executables layout))
        (define base-env-vars (local-layout-env-vars layout))
+       ;; Restore user's saved PLTCOMPILEDROOTS (if any) for the probe.
+       ;; bin/rackup saves it as _RACKUP_ORIG_PLTCOMPILEDROOTS before
+       ;; unsetting it for the rackup-core runtime.
+       (define saved-compiled-roots (getenv "_RACKUP_ORIG_PLTCOMPILEDROOTS"))
+       (define probe-env-vars
+         (if saved-compiled-roots
+             (cons (cons "PLTCOMPILEDROOTS" saved-compiled-roots) base-env-vars)
+             base-env-vars))
        (define-values (version* variant* addon-dir*)
-         (probe-local-racket-version+variant+addon-dir (path->string* real-bin-dir) base-env-vars))
-       (define env-vars (local-layout-env-vars layout addon-dir*))
+         (probe-local-racket-version+variant+addon-dir (path->string* real-bin-dir) probe-env-vars))
+       (define env-vars (local-layout-env-vars layout addon-dir* version* variant*))
        (make-bin-overlay! id real-bin-dir extra-exes)
        (maybe-wrap-local-chez-extra-executables! id extra-exes layout)
        (if (pair? env-vars)
@@ -907,7 +946,7 @@
          (define real-bin-dir (detect-bin-dir install-root))
          (maybe-modernize-legacy-archsys! real-bin-dir)
          (make-bin-link! id real-bin-dir)
-         (define env-vars (installed-toolchain-env-vars real-bin-dir))
+         (define env-vars (installed-toolchain-env-vars real-bin-dir request))
          (if (pair? env-vars)
              (write-toolchain-env-file! id env-vars)
              (delete-toolchain-env-file! id))
@@ -924,10 +963,12 @@
            (printf "\nTip: to get the full Racket distribution, run:\n  raco pkg install main-distribution\n"))
          id)])))
 
-(define (remove-toolchain! id)
+(define (remove-toolchain! id #:clean-compiled? [clean-compiled? #f])
   (ensure-index!)
   (unless (toolchain-exists? id)
     (rackup-error "toolchain not installed: ~a" id))
+  (when clean-compiled?
+    (clean-toolchain-compiled-dirs! id))
   (define tc-dir (rackup-toolchain-dir id))
   (define addon (rackup-addon-dir id))
   (when (directory-exists? tc-dir)
@@ -956,6 +997,117 @@
          #:env (toolchain-runtime-env id)
          raco-exe
          raco-args))
+
+;; Run racket -e with the correct env for a toolchain.  Returns stdout
+;; as a string on success, #f on failure.
+(define (capture-racket-eval-output id expr-text)
+  (define bin (rackup-toolchain-bin-link id))
+  (define racket-exe (build-path bin "racket"))
+  (capture-program-output
+   #:env (toolchain-runtime-env id)
+   racket-exe
+   "-e"
+   expr-text))
+
+;; A small Racket program that prints the absolute source directory of
+;; every user-scope package, one per line.  Covers both catalog
+;; installs and `raco pkg install --link` installs.
+(define list-pkg-dirs-program
+  (string-join
+   '("(begin"
+     " (require pkg/lib racket/path)"
+     " (parameterize ([current-pkg-scope 'user])"
+     "  (with-pkg-lock/read-only"
+     "   (define cache (make-hash))"
+     "   (for ([name (in-list (sort (hash-keys (installed-pkg-table)) string<?))])"
+     "    (define dir (pkg-directory name #:cache cache))"
+     "    (when dir"
+     "     (displayln"
+     "      (path->string"
+     "       (simplify-path (path->complete-path dir)))))))))")
+   " "))
+
+;; Query the toolchain for absolute source directories of all
+;; user-scope packages (catalog and linked).  Returns a list of strings,
+;; or #f if the toolchain's racket cannot be invoked.
+(define (toolchain-user-package-dirs id)
+  (define out
+    (with-handlers ([exn:fail? (lambda (_) #f)])
+      (capture-racket-eval-output id list-pkg-dirs-program)))
+  (cond
+    [(or (not out) (string-blank? out)) null]
+    [else
+     (for/list ([line (in-list (string-split out "\n"))]
+                #:when (not (string-blank? line)))
+       (string-trim line))]))
+
+;; Recursively find directories named `target` (a string) under `root`
+;; and call `proc` on each one.  Does not descend into the matched
+;; directories.  Skips symlinks to avoid escaping the root or looping.
+(define (for-each-named-subdir root target proc)
+  (define (walk dir)
+    (when (and (directory-exists? dir) (not (link-exists? dir)))
+      (for ([entry (in-list (with-handlers ([exn:fail? (lambda (_) null)])
+                              (directory-list dir #:build? #t)))])
+        (cond
+          [(link-exists? entry) (void)]
+          [(directory-exists? entry)
+           (cond
+             [(equal? (path-basename-string entry) target)
+              (proc entry)]
+             [else (walk entry)])]))))
+  (walk root))
+
+;; Walk the package source directories of toolchain `id` and remove any
+;; `compiled/<key>/` subdirectories, where `<key>` is derived from the
+;; toolchain's version+variant.  Reports what was removed.
+(define (clean-toolchain-compiled-dirs! id)
+  (define meta (read-toolchain-meta id))
+  (unless (hash? meta)
+    (install-warn "Cannot clean compiled dirs: missing metadata for ~a" id)
+    (set! meta (hash)))
+  (define key-value
+    (compiled-roots-value (hash-ref meta 'resolved-version #f)
+                          (hash-ref meta 'variant #f)))
+  (cond
+    [(not key-value)
+     (install-warn
+      "Cannot clean compiled dirs for ~a: no usable version+variant in metadata"
+      id)]
+    [else
+     ;; key-value is "compiled/<key>:." -- extract just <key>.
+     (define key
+       (let* ([before-colon (car (string-split key-value ":"))]
+              [after-slash (cadr (string-split before-colon "/"))])
+         after-slash))
+     (install-info "Scanning user packages for compiled/~a directories..." key)
+     (define dirs (toolchain-user-package-dirs id))
+     (cond
+       [(null? dirs)
+        (install-info "No user packages with source directories found.")]
+       [else
+        (define removed 0)
+        (define addon (path->string* (rackup-addon-dir id)))
+        (for ([d (in-list dirs)])
+          (define d-path (string->path d))
+          (when (directory-exists? d-path)
+            (for-each-named-subdir
+             d-path
+             "compiled"
+             (lambda (compiled-dir)
+               (define versioned (build-path compiled-dir key))
+               (when (and (directory-exists? versioned) (not (link-exists? versioned)))
+                 (with-handlers ([exn:fail?
+                                  (lambda (e)
+                                    (install-warn "Failed to remove ~a: ~a"
+                                                  (path->string* versioned)
+                                                  (exn-message e)))])
+                   (delete-directory/files versioned)
+                   (set! removed (+ removed 1))))))))
+        (install-ok "Cleaned ~a compiled/~a director~a"
+                    removed
+                    key
+                    (if (= removed 1) "y" "ies"))])]))
 
 ;; Parse the output of `raco pkg show --user` into a list of package
 ;; names.  The format is a header line ("Package  Checksum  Source")
@@ -1160,4 +1312,6 @@
            installed-toolchain-env-vars
            ensure-installer-cached!
            parse-pkg-show-output
-           meta->upgrade-spec))
+           meta->upgrade-spec
+           write-toolchain-env-file!
+           clean-toolchain-compiled-dirs!))

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -415,9 +415,13 @@
      (restore-saved-racket-env-vars! env)
      (environment-variables-set! env #"RACKUP_TOOLCHAIN" (string->bytes/utf-8 id))
      (for ([kv (in-list (toolchain-runtime-env-vars id))])
-       (environment-variables-set! env
-                                   (string->bytes/utf-8 (car kv))
-                                   (string->bytes/utf-8 (cdr kv))))
+       (define key (string->bytes/utf-8 (car kv)))
+       ;; For PLTCOMPILEDROOTS, respect a user-set value restored above.
+       (unless (and (equal? (car kv) "PLTCOMPILEDROOTS")
+                    (environment-variables-ref env key))
+         (environment-variables-set! env
+                                     key
+                                     (string->bytes/utf-8 (cdr kv)))))
      (define old-path (or (getenv "PATH") ""))
      (define shims (path->string (rackup-shims-dir)))
      (define runtime-path
@@ -478,19 +482,29 @@
             (if (= (length targets) 1) "" "s"))))
 
 (define (cmd-remove rest)
+  (define clean-compiled? #f)
   (define spec
     (command-line #:program "rackup remove"
                   #:argv rest
+                  #:once-each
+                  [("--clean-compiled")
+                   ("Remove version-specific compiled/<key>/ directories"
+                    "from user-scope and linked package source directories")
+                   (set! clean-compiled? #t)]
                   #:args (spec)
                   spec))
   (define installed-id (find-local-toolchain spec))
   (cond
-    [installed-id (remove-toolchain! installed-id)]
+    [installed-id (remove-toolchain! installed-id #:clean-compiled? clean-compiled?)]
     [else
      (define orphan-id (find-orphan-toolchain-id spec))
-     (if orphan-id
-         (remove-orphan-toolchain! orphan-id)
-         (rackup-error "no matching installed toolchain: ~a" spec))]))
+     (cond
+       [orphan-id
+        (when clean-compiled?
+          (rackup-error "--clean-compiled cannot be used with orphan toolchains"))
+        (remove-orphan-toolchain! orphan-id)]
+       [else
+        (rackup-error "no matching installed toolchain: ~a" spec)])]))
 
 (define (cmd-reshim rest)
   (define aliases? #f)

--- a/libexec/rackup/shell.rkt
+++ b/libexec/rackup/shell.rkt
@@ -288,26 +288,19 @@
 (define (emit-env-exports vars)
   (apply string-append
          (for/list ([kv (in-list vars)])
-           (define k (car kv))
-           (define v (cdr kv))
-           (format "export ~a=~a\n" k (sh-single-quote v)))))
+           (env-var-export-line (car kv) (cdr kv)))))
 
 (define (emit-shell-activation toolchain-id)
   (unless (toolchain-exists? toolchain-id)
     (rackup-error "toolchain not installed: ~a" toolchain-id))
-  (define extra-env (toolchain-env-vars toolchain-id))
-  (define addon (path->string* (rackup-addon-dir toolchain-id)))
-  (define has-addon? (assoc "PLTADDONDIR" extra-env))
+  ;; Only set RACKUP_TOOLCHAIN and PATH.  Racket-specific env vars
+  ;; (PLTCOMPILEDROOTS, PLTADDONDIR, PLTHOME) are set internally by the
+  ;; shim dispatcher via env.sh, scoped to each invocation — not exported
+  ;; into the user's shell where they would leak into non-rackup commands.
   (string-append (emit-path-prepend)
-                 (emit-env-exports extra-env)
                  "export RACKUP_TOOLCHAIN="
                  (sh-single-quote toolchain-id)
-                 "\n"
-                 (if has-addon?
-                     ""
-                     (string-append "export PLTADDONDIR="
-                                    (sh-single-quote addon)
-                                    "\n"))))
+                 "\n"))
 
 (define (deactivation-extra-vars)
   (define active (getenv "RACKUP_TOOLCHAIN"))
@@ -319,12 +312,16 @@
 
 (define (emit-shell-deactivation)
   (define extra-vars (remove-duplicates (deactivation-extra-vars)))
+  ;; Unset RACKUP_TOOLCHAIN and any Racket env vars that might be
+  ;; lingering from prior sessions (backwards compatibility).
   (string-append (emit-path-prepend)
                  (apply string-append
                         (for/list ([k (in-list extra-vars)])
                           (format "unset ~a\n" k)))
                  "unset RACKUP_TOOLCHAIN\n"
-                 "unset PLTADDONDIR\n"))
+                 "unset PLTADDONDIR\n"
+                 "unset PLTCOMPILEDROOTS\n"
+                 "unset PLTHOME\n"))
 
 (define (guess-shell)
   (define sh (or (getenv "SHELL") ""))

--- a/libexec/rackup/shims.rkt
+++ b/libexec/rackup/shims.rkt
@@ -354,7 +354,7 @@ EOF
                    "# rackup managed toolchain environment\n"
                    (apply string-append
                           (for/list ([kv (in-list env-vars)])
-                            (format "export ~a=~a\n" (car kv) (sh-single-quote (cdr kv)))))))
+                            (env-var-export-line (car kv) (cdr kv))))))
   (write-string-file p body)
   (file-or-directory-permissions p #o644))
 
@@ -373,25 +373,65 @@ EOF
     (or old-addon-dir
         (and source-root
              (path->string* (build-path (string->path source-root) "add-on")))))
-  (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
-      (list (cons "PLTADDONDIR" effective-addon-dir))
-      null))
+  (define addon-entry
+    (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
+        (list (cons "PLTADDONDIR" effective-addon-dir))
+        null))
+  (define real-bin-dir-str (hash-ref meta 'real-bin-dir #f))
+  (define existing-roots
+    (if real-bin-dir-str
+        (read-toolchain-compiled-file-roots (string->path real-bin-dir-str))
+        '(same)))
+  (define compiled-roots-entry
+    (cond
+      [(compiled-roots-value (hash-ref meta 'resolved-version #f)
+                             (hash-ref meta 'variant #f)
+                             existing-roots)
+       =>
+       (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
+      [else null]))
+  (append addon-entry compiled-roots-entry))
+
+;; Backfill PLTCOMPILEDROOTS into an installed toolchain whose metadata
+;; predates per-toolchain compiled roots.  Adds the entry to env-vars in
+;; meta.rktd and rewrites env.sh.  Idempotent: does nothing if the
+;; toolchain already has PLTCOMPILEDROOTS or if a value cannot be
+;; computed from its version+variant.
+(define (backfill-installed-env-vars! id meta)
+  (define current (meta->env-vars meta))
+  (define has-pcr? (assoc "PLTCOMPILEDROOTS" current))
+  (define computed-pcr
+    (compiled-roots-value (hash-ref meta 'resolved-version #f)
+                          (hash-ref meta 'variant #f)))
+  (when (and computed-pcr (not has-pcr?))
+    (define new-env-vars
+      (append current (list (cons "PLTCOMPILEDROOTS" computed-pcr))))
+    (define new-meta
+      (hash-set meta 'env-vars
+                (for/list ([kv (in-list new-env-vars)])
+                  (list (car kv) (cdr kv)))))
+    (write-toolchain-meta! id new-meta)
+    (write-env-file! id new-env-vars)))
 
 (define (regenerate-env-files!)
   (for ([id (in-list (installed-toolchain-ids))])
     (define meta (read-toolchain-meta id))
     (when (hash? meta)
       (define kind (hash-ref meta 'kind #f))
-      ;; Only regenerate env files for local (linked) toolchains, where
-      ;; the env vars are derived from the source layout and the
-      ;; computation may have changed.  Installed (release/snapshot)
-      ;; toolchains have env vars computed once at install time and
-      ;; stored in the meta; they don't need regeneration.
-      (when (eq? kind 'local)
-        (define env-vars (compute-local-env-vars meta))
-        (if (pair? env-vars)
-            (write-env-file! id env-vars)
-            (delete-env-file! id))))))
+      (cond
+        ;; Local (linked) toolchains: regenerate env vars from the
+        ;; source layout (which may have changed).
+        [(eq? kind 'local)
+         (define env-vars (compute-local-env-vars meta))
+         (if (pair? env-vars)
+             (write-env-file! id env-vars)
+             (delete-env-file! id))]
+        ;; Installed toolchains: env vars are normally computed once at
+        ;; install time and stored in meta, but backfill PLTCOMPILEDROOTS
+        ;; for toolchains that were installed by an older rackup which
+        ;; did not compute it.
+        [else
+         (backfill-installed-env-vars! id meta)]))))
 
 (define/state-locked (reshim!)
   (regenerate-env-files!)

--- a/libexec/rackup/shims.rkt
+++ b/libexec/rackup/shims.rkt
@@ -382,11 +382,15 @@ EOF
     (if real-bin-dir-str
         (read-toolchain-compiled-file-roots (string->path real-bin-dir-str))
         '(same)))
+  (define local-name
+    (and (eq? (hash-ref meta 'kind #f) 'local)
+         (hash-ref meta 'requested-spec #f)))
   (define compiled-roots-entry
     (cond
       [(compiled-roots-value (hash-ref meta 'resolved-version #f)
                              (hash-ref meta 'variant #f)
-                             existing-roots)
+                             existing-roots
+                             local-name)
        =>
        (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
       [else null]))

--- a/libexec/rackup/state.rkt
+++ b/libexec/rackup/state.rkt
@@ -168,12 +168,16 @@
 ;; roots.  `existing-roots` is a list as found in config.rktd's
 ;; 'compiled-file-roots key (e.g., (same) for in-place installs, or
 ;; ("/usr/lib/racket/compiled") for FHS installs).  When not provided,
-;; defaults to (same).
+;; defaults to (same).  `local-name` is the local name of a linked
+;; toolchain (e.g., "dev" for `rackup link dev`), and when non-#f is
+;; appended to the key so locally-built toolchains don't share
+;; compiled-file directories with release installs of the same
+;; version+variant.
 ;;
 ;; Returns a string like "compiled/9.1-cs:." or
-;; "compiled/9.1-cs:/usr/lib/racket/compiled", or #f when the
-;; version/variant are too incomplete to form a stable key.
-(define (compiled-roots-value version variant [existing-roots '(same)])
+;; "compiled/9.1-cs-local-dev:." (for linked toolchains), or #f when
+;; the version/variant are too incomplete to form a stable key.
+(define (compiled-roots-value version variant [existing-roots '(same)] [local-name #f])
   (define variant-str
     (cond
       [(symbol? variant) (and (not (eq? variant 'unknown)) (symbol->string variant))]
@@ -184,9 +188,14 @@
       [(and (string? version) (not (string-blank? version)) (not (equal? version "local")))
        version]
       [else #f]))
+  (define local-suffix
+    (cond
+      [(and (string? local-name) (not (string-blank? local-name)))
+       (format "-local-~a" local-name)]
+      [else ""]))
   (cond
     [(and version-str variant-str)
-     (define key (format "compiled/~a-~a" version-str variant-str))
+     (define key (format "compiled/~a-~a~a" version-str variant-str local-suffix))
      ;; Always include 'same (serialized as ".") so that user code's
      ;; compiled/ directories are found, even on FHS installs where the
      ;; existing roots only contain absolute reroot paths for system

--- a/libexec/rackup/state.rkt
+++ b/libexec/rackup/state.rkt
@@ -22,6 +22,9 @@
          read-toolchain-meta
          write-toolchain-meta!
          toolchain-env-vars
+         meta->env-vars
+         compiled-roots-value
+         read-toolchain-compiled-file-roots
          register-toolchain!
          unregister-toolchain!
          find-local-toolchain
@@ -109,8 +112,7 @@
 (define (write-toolchain-meta! id meta)
   (write-rktd-file (rackup-toolchain-meta-file id) meta))
 
-(define (toolchain-env-vars id)
-  (define m (read-toolchain-meta id))
+(define (meta->env-vars m)
   (define raw (and (hash? m) (hash-ref m 'env-vars #f)))
   (cond
     [(hash? raw)
@@ -121,6 +123,80 @@
                 #:when (and (list? entry) (= (length entry) 2)))
        (cons (format "~a" (car entry)) (format "~a" (cadr entry))))]
     [else null]))
+
+(define (toolchain-env-vars id)
+  (meta->env-vars (read-toolchain-meta id)))
+
+;; Read the compiled-file-roots from a toolchain's config.rktd.
+;; Returns a list like (same) or ("/usr/lib/racket/compiled"), or
+;; (same) as default if the file is missing or has no entry.
+(define (read-toolchain-compiled-file-roots real-bin-dir)
+  (define parent
+    (and real-bin-dir
+         (let-values ([(d _ __) (split-path (if (path? real-bin-dir)
+                                                real-bin-dir
+                                                (string->path (format "~a" real-bin-dir))))])
+           d)))
+  (define candidates
+    (if parent
+        (list (build-path parent "etc" "config.rktd")
+              (build-path parent "etc" "racket" "config.rktd"))
+        null))
+  (define config
+    (for/or ([p (in-list candidates)])
+      (and (file-exists? p)
+           (with-handlers ([exn:fail? (lambda (_) #f)])
+             (call-with-input-file p read)))))
+  (cond
+    [(and (hash? config) (list? (hash-ref config 'compiled-file-roots #f)))
+     (hash-ref config 'compiled-file-roots)]
+    [else '(same)]))
+
+;; Serialize a compiled-file-roots entry (as found in config.rktd or
+;; returned by find-compiled-file-roots) into a string suitable for a
+;; colon-separated PLTCOMPILEDROOTS value.  'same cannot be represented
+;; directly, but "." is a relative path that resolves equivalently.
+(define (serialize-compiled-root r)
+  (cond
+    [(eq? r 'same) "."]
+    [(path? r) (path->string r)]
+    [(string? r) r]
+    [else (format "~a" r)]))
+
+;; Compute a PLTCOMPILEDROOTS value that prepends a version-variant-
+;; specific subdirectory to the toolchain's existing compiled-file
+;; roots.  `existing-roots` is a list as found in config.rktd's
+;; 'compiled-file-roots key (e.g., (same) for in-place installs, or
+;; ("/usr/lib/racket/compiled") for FHS installs).  When not provided,
+;; defaults to (same).
+;;
+;; Returns a string like "compiled/9.1-cs:." or
+;; "compiled/9.1-cs:/usr/lib/racket/compiled", or #f when the
+;; version/variant are too incomplete to form a stable key.
+(define (compiled-roots-value version variant [existing-roots '(same)])
+  (define variant-str
+    (cond
+      [(symbol? variant) (and (not (eq? variant 'unknown)) (symbol->string variant))]
+      [(string? variant) (and (not (string-blank? variant)) variant)]
+      [else #f]))
+  (define version-str
+    (cond
+      [(and (string? version) (not (string-blank? version)) (not (equal? version "local")))
+       version]
+      [else #f]))
+  (cond
+    [(and version-str variant-str)
+     (define key (format "compiled/~a-~a" version-str variant-str))
+     ;; Always include 'same (serialized as ".") so that user code's
+     ;; compiled/ directories are found, even on FHS installs where the
+     ;; existing roots only contain absolute reroot paths for system
+     ;; collections.
+     (define roots-with-same
+       (let ([roots (if (null? existing-roots) '(same) existing-roots)])
+         (if (memq 'same roots) roots (append roots '(same)))))
+     (define fallbacks (map serialize-compiled-root roots-with-same))
+     (string-join (cons key fallbacks) ":")]
+    [else #f]))
 
 (define (meta-summary meta)
   (for/hash ([k '(id kind

--- a/libexec/rackup/util.rkt
+++ b/libexec/rackup/util.rkt
@@ -34,6 +34,7 @@
          ensure-string-without-control-chars!
          ensure-path-without-control-chars!
          sh-single-quote
+         env-var-export-line
          color-enabled?
          ansi
          sanitized-racket-env-vars
@@ -228,6 +229,12 @@
 (define (sh-single-quote s)
   (define str (format "~a" s))
   (string-append "'" (regexp-replace* #px"'" str "'\"'\"'") "'"))
+
+;; Produce a shell `export` line for an env-var pair.
+;; env.sh is sourced by the shim dispatcher, scoped to each invocation.
+;; All variables are exported unconditionally.
+(define (env-var-export-line key value)
+  (format "export ~a=~a\n" key (sh-single-quote value)))
 
 ;; Racket env vars that bin/rackup saves as _RACKUP_ORIG_* and clears
 ;; so the hidden runtime is not affected. restore-saved-racket-env-vars!

--- a/test/e2e-fresh-container.sh
+++ b/test/e2e-fresh-container.sh
@@ -242,6 +242,11 @@ create_fake_local_source_tree() {
 set -euo pipefail
 default_addon_dir="$(cd "$(dirname "$0")/../.." && pwd)/add-on/development"
 if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
+  # Combined probe: all three queries in one -e call
+  if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
+    printf '9.99-local\nchez-scheme\n%s' "${PLTADDONDIR:-$default_addon_dir}"
+    exit 0
+  fi
   case "$2" in
     *"(version)"*) printf '9.99-local'; exit 0 ;;
     *"system-type 'vm"*) printf 'cs'; exit 0 ;;
@@ -350,7 +355,10 @@ shell_eval_snippet_test() {
 set -euo pipefail
 eval "\$("$RACKUP_BIN" switch "$toolchain_id")"
 test "\${RACKUP_TOOLCHAIN}" = "$toolchain_id"
-test "\${PLTADDONDIR}" = "$RACKUP_HOME/addons/$toolchain_id"
+# PLTADDONDIR is set internally by the shim dispatcher, not exported
+# to the shell.  Verify it reaches the toolchain's racket via the shim.
+addon="\$(racket -e '(display (getenv "PLTADDONDIR"))' 2>&1)" || { echo "racket addon probe failed: \$addon" >&2; exit 1; }
+test "\$addon" = "$RACKUP_HOME/addons/$toolchain_id" || { echo "addon mismatch: got='\$addon' expected='$RACKUP_HOME/addons/$toolchain_id'" >&2; exit 1; }
 v="\$(racket -e '(display (version))')"
 case "\$v" in
   ${expected_prefix}*) ;;

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -24,7 +24,8 @@
          "../libexec/rackup/util.rkt"
          "../libexec/rackup/versioning.rkt"
          (only-in (submod "../libexec/rackup/install.rkt" for-testing)
-                  detect-bin-dir installed-toolchain-env-vars)
+                  detect-bin-dir installed-toolchain-env-vars
+                  write-toolchain-env-file! clean-toolchain-compiled-dirs!)
          (only-in (submod "../libexec/rackup/runtime.rkt" for-testing)
                   hidden-runtime-invocation-prefix)
          (submod "../libexec/rackup/shell.rkt" for-testing))
@@ -528,6 +529,10 @@
                 @~a{#!/usr/bin/env bash
                     set -euo pipefail
                     if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
+                      if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
+                        printf '9.99-local\nchez-scheme\n@|addon-dir|'
+                        exit 0
+                      fi
                       case "$2" in
                         *"(version)"*) printf '9.99-local'; exit 0 ;;
                         *"system-type 'vm"*) printf 'cs'; exit 0 ;;
@@ -571,6 +576,11 @@
                 @~a{#!/usr/bin/env bash
                     set -euo pipefail
                     if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
+                      # Combined probe: all three queries in one -e call
+                      if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
+                        printf '9.98-local\nchez-scheme\n@|addon-dir|'
+                        exit 0
+                      fi
                       case "$2" in
                         *"(version)"*) printf '9.98-local'; exit 0 ;;
                         *"system-type 'vm"*) printf 'cs'; exit 0 ;;
@@ -610,7 +620,8 @@
      (check-true (regexp-match?
                   (regexp (regexp-quote (format "PLTADDONDIR=~a"
                                                 (path->string addon-dir))))
-                  shim-out))
+                  shim-out)
+                 "shim dispatcher sets PLTADDONDIR")
 
      (define scheme-out
        (capture-output
@@ -625,9 +636,13 @@
                                                       (path->string petite-boot))))
 
      (define activation (emit-shell-activation linked-id))
+     ;; Shell activation should only set RACKUP_TOOLCHAIN and PATH.
+     ;; Racket env vars are set internally by the shim dispatcher.
      (check-false (string-contains? activation "export PLTHOME="))
      (check-false (string-contains? activation "export PLTCOLLECTS="))
-     (check-true (string-contains? activation (format "export PLTADDONDIR='~a'" (path->string addon-dir))))
+     (check-false (string-contains? activation "export PLTADDONDIR="))
+     (check-false (string-contains? activation "export PLTCOMPILEDROOTS="))
+     (check-true (string-contains? activation "export RACKUP_TOOLCHAIN="))
      (expect (run-main (list "switch" "devsrc")) activation)
      @expect[(run-main '("prompt"))]{devsrc
 }
@@ -641,8 +656,12 @@
 }
      (void (putenv "RACKUP_TOOLCHAIN" linked-id))
      (define deactivation (emit-shell-deactivation))
-     (check-false (string-contains? deactivation "unset PLTHOME"))
-     (check-false (string-contains? deactivation "unset PLTCOLLECTS"))
+     ;; Deactivation unsets RACKUP_TOOLCHAIN and Racket env vars
+     ;; (for backwards compatibility with sessions that have them set).
+     (check-true (string-contains? deactivation "unset RACKUP_TOOLCHAIN"))
+     (check-true (string-contains? deactivation "unset PLTADDONDIR"))
+     (check-true (string-contains? deactivation "unset PLTCOMPILEDROOTS"))
+     (check-true (string-contains? deactivation "unset PLTHOME"))
      (expect (run-main '("switch" "--unset")) deactivation)
      (void (putenv "RACKUP_TOOLCHAIN" ""))))
 
@@ -717,6 +736,10 @@
                     @~a{#!/usr/bin/env bash
                         set -euo pipefail
                         if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
+                          if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
+                            printf '8.18-installed\nchez-scheme\n@|addon-dir|'
+                            exit 0
+                          fi
                           case "$2" in
                             *"(version)"*) printf '8.18-installed'; exit 0 ;;
                             *"system-type 'vm"*) printf 'cs'; exit 0 ;;
@@ -794,6 +817,10 @@
                         @~a{#!/usr/bin/env bash
                             set -euo pipefail
                             if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
+                              if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
+                                printf '9.90-local\nchez-scheme\n'
+                                exit 0
+                              fi
                               case "$2" in
                                 *"(version)"*) printf '9.90-local'; exit 0 ;;
                                 *"system-type 'vm"*) printf 'cs'; exit 0 ;;
@@ -2102,3 +2129,417 @@
         (if old-cr
             (putenv "PLTCOMPILEDROOTS" old-cr)
             (putenv "PLTCOMPILEDROOTS" ""))))))
+
+  ;; Unit tests: compiled-roots-value
+  (check-equal? (compiled-roots-value "9.1" 'cs) "compiled/9.1-cs:."
+                "default roots (same) => . fallback")
+  (check-equal? (compiled-roots-value "9.1.0.3" 'bc) "compiled/9.1.0.3-bc:."
+                "multi-component version")
+  (check-equal? (compiled-roots-value "9.1" "cs") "compiled/9.1-cs:."
+                "string version + string variant")
+  (check-equal? (compiled-roots-value "9.1" 'cs '("/usr/lib/racket/compiled"))
+                "compiled/9.1-cs:/usr/lib/racket/compiled:."
+                "FHS layout: absolute reroot path + . for user code")
+  (check-equal? (compiled-roots-value "9.1" 'cs '("/abs/root" same))
+                "compiled/9.1-cs:/abs/root:."
+                "mixed roots: absolute + same (no duplicate .)")
+  (check-false (compiled-roots-value "9.1" 'unknown) "variant 'unknown disables")
+  (check-false (compiled-roots-value "local" 'cs) "\"local\" version disables")
+  (check-false (compiled-roots-value #f 'cs) "#f version disables")
+  (check-false (compiled-roots-value "9.1" #f) "#f variant disables")
+  (check-false (compiled-roots-value "" 'cs) "blank version disables")
+
+  ;; Unit tests: env-var-export-line — all vars exported unconditionally
+  (check-equal? (env-var-export-line "PLTADDONDIR" "/foo/bar")
+                "export PLTADDONDIR='/foo/bar'\n"
+                "PLTADDONDIR is exported unconditionally")
+  (check-equal? (env-var-export-line "PLTCOMPILEDROOTS" "compiled/9.1-cs:.")
+                "export PLTCOMPILEDROOTS='compiled/9.1-cs:.'\n"
+                "PLTCOMPILEDROOTS is exported unconditionally")
+
+  ;; Integration test: installed toolchain metadata includes PLTCOMPILEDROOTS
+  ;; and the dispatcher/env.sh honors the user's existing value
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (ensure-index!)
+     (setup-hidden-runtime! tmp)
+     (define id "release-9.1-cs-x86_64-linux-full")
+     (define install-root (rackup-toolchain-install-dir id))
+     (define real-bin (build-path install-root "bin"))
+     (make-directory* real-bin)
+     (write-string-file (build-path real-bin "racket")
+                        "#!/usr/bin/env bash\necho test\n")
+     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (define print-cr (build-path real-bin "print-compiled-roots"))
+     (write-string-file print-cr
+                        "#!/usr/bin/env bash\nprintf 'PLTCOMPILEDROOTS=%s\\n' \"${PLTCOMPILEDROOTS:-}\"\n")
+     (file-or-directory-permissions print-cr #o755)
+     (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
+
+     ;; Simulate install-time env-var computation
+     (define env-vars (installed-toolchain-env-vars real-bin
+                                                    (hash 'resolved-version "9.1"
+                                                          'variant 'cs)))
+     (check-not-false (assoc "PLTCOMPILEDROOTS" env-vars)
+                      "installed-toolchain-env-vars returns PLTCOMPILEDROOTS entry")
+     (check-equal? (cdr (assoc "PLTCOMPILEDROOTS" env-vars)) "compiled/9.1-cs:."
+                   "PLTCOMPILEDROOTS value matches compiled-roots-value")
+
+     (with-state-lock
+       (register-toolchain! id
+                            (hash 'id id 'kind 'release 'requested-spec "9.1"
+                                  'resolved-version "9.1" 'variant 'cs 'distribution 'full
+                                  'arch "x86_64" 'platform "linux"
+                                  'env-vars (for/list ([kv (in-list env-vars)])
+                                              (list (car kv) (cdr kv)))
+                                  'executables '("racket" "print-compiled-roots")
+                                  'installed-at "2026-03-01T00:00:00Z")))
+     ;; Write the env.sh as the install flow would
+     (write-toolchain-env-file! id env-vars)
+
+     ;; env.sh should contain an unconditional export for PLTCOMPILEDROOTS
+     (define env-sh-content
+       (file->string (rackup-toolchain-env-file id)))
+     (check-true (string-contains? env-sh-content "export PLTCOMPILEDROOTS='compiled/9.1-cs:.'")
+                 "env.sh contains unconditional PLTCOMPILEDROOTS export")
+     (check-false (regexp-match? #px"if \\[ -z \"\\$\\{PLTCOMPILEDROOTS:-\\}\" \\];"
+                                 env-sh-content)
+                  "env.sh does NOT use conditional guard")
+
+     ;; Verify rackup run respects user-set PLTCOMPILEDROOTS
+     (define old-cr (getenv "PLTCOMPILEDROOTS"))
+     (dynamic-wind
+      (lambda ()
+        (putenv "PLTCOMPILEDROOTS" "user-override"))
+      (lambda ()
+        (expect (begin (apply system* rackup-bin (list "run" id "--" "print-compiled-roots")) (void))
+                "PLTCOMPILEDROOTS=user-override" #:match 'contains))
+      (lambda ()
+        (if old-cr
+            (putenv "PLTCOMPILEDROOTS" old-cr)
+            (putenv "PLTCOMPILEDROOTS" ""))))
+
+     ;; And when user has no PLTCOMPILEDROOTS, rackup run sets the toolchain default
+     (dynamic-wind
+      (lambda () (putenv "PLTCOMPILEDROOTS" ""))
+      (lambda ()
+        (expect (begin (apply system* rackup-bin (list "run" id "--" "print-compiled-roots")) (void))
+                "PLTCOMPILEDROOTS=compiled/9.1-cs:." #:match 'contains))
+      (lambda ()
+        (if old-cr
+            (putenv "PLTCOMPILEDROOTS" old-cr)
+            (putenv "PLTCOMPILEDROOTS" ""))))))
+
+  ;; Integration test: clean-toolchain-compiled-dirs! walks linked package
+  ;; directories (reported by the toolchain's racket) and removes
+  ;; compiled/<key>/ subdirs.
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (ensure-index!)
+     (define id "release-9.1-cs-x86_64-linux-full")
+     (define install-root (rackup-toolchain-install-dir id))
+     (define real-bin (build-path install-root "bin"))
+     (make-directory* real-bin)
+
+     ;; Build a fake package source tree with compiled/<key>/ dirs at two
+     ;; nesting levels and an unrelated compiled/other/ dir that must
+     ;; NOT be removed.
+     (define pkg-dir (build-path tmp "fake-pkg"))
+     (make-directory* (build-path pkg-dir "compiled" "9.1-cs"))
+     (make-directory* (build-path pkg-dir "compiled" "other"))
+     (make-directory* (build-path pkg-dir "sub" "compiled" "9.1-cs"))
+     (write-string-file (build-path pkg-dir "compiled" "9.1-cs" "foo.zo") "zo")
+     (write-string-file (build-path pkg-dir "compiled" "other" "foo.zo") "zo")
+     (write-string-file (build-path pkg-dir "sub" "compiled" "9.1-cs" "bar.zo") "zo")
+
+     ;; Fake racket prints the package source directory, mimicking the
+     ;; Racket program that uses pkg/lib.  Only -e invocations matter;
+     ;; ignore other raco subcommands for this test.
+     (define racket-exe (build-path real-bin "racket"))
+     (write-string-file racket-exe
+                        (string-append
+                         "#!/usr/bin/env bash\n"
+                         "if [ \"${1:-}\" = \"-e\" ]; then\n"
+                         "  printf '%s\\n' " (sh-single-quote (path->string pkg-dir)) "\n"
+                         "  exit 0\n"
+                         "fi\n"
+                         "exit 0\n"))
+     (file-or-directory-permissions racket-exe #o755)
+     (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
+
+     (with-state-lock
+       (register-toolchain! id
+                            (hash 'id id 'kind 'release 'requested-spec "9.1"
+                                  'resolved-version "9.1" 'variant 'cs 'distribution 'full
+                                  'arch "x86_64" 'platform "linux"
+                                  'executables '("racket")
+                                  'installed-at "2026-03-01T00:00:00Z")))
+
+     ;; Sanity: all three compiled dirs exist up front
+     (check-true (directory-exists? (build-path pkg-dir "compiled" "9.1-cs")))
+     (check-true (directory-exists? (build-path pkg-dir "compiled" "other")))
+     (check-true (directory-exists? (build-path pkg-dir "sub" "compiled" "9.1-cs")))
+
+     (clean-toolchain-compiled-dirs! id)
+
+     ;; The version-specific dirs should be removed, the unrelated one kept
+     (check-false (directory-exists? (build-path pkg-dir "compiled" "9.1-cs"))
+                  "top-level compiled/9.1-cs removed")
+     (check-false (directory-exists? (build-path pkg-dir "sub" "compiled" "9.1-cs"))
+                  "nested compiled/9.1-cs removed")
+     (check-true (directory-exists? (build-path pkg-dir "compiled" "other"))
+                 "compiled/other preserved")
+     (check-true (file-exists? (build-path pkg-dir "compiled" "other" "foo.zo"))
+                 "compiled/other contents preserved")))
+
+  ;; End-to-end integration test: after the shell-activation pipeline has
+  ;; established PLTCOMPILEDROOTS, `raco make` compiles into the
+  ;; version-variant subdirectory rather than the default `compiled`
+  ;; directory.  Uses the real system racket/raco via symlinks into a
+  ;; fake toolchain bin dir so that compilation actually happens.
+  (let ()
+    (define real-racket
+      (simplify-path (resolve-path (find-system-path 'exec-file)) #t))
+    (define real-bin-dir (let-values ([(d _ __) (split-path real-racket)]) d))
+    (define real-raco
+      (and real-bin-dir (build-path real-bin-dir "raco")))
+    (when (and real-bin-dir (file-exists? (or real-raco "")))
+      (with-temp-rackup-home
+       (lambda (tmp)
+         (ensure-index!)
+         (setup-hidden-runtime! tmp)
+         (define id "release-test-cs-x86_64-linux-full")
+         (define install-root (rackup-toolchain-install-dir id))
+         (define tc-bin (build-path install-root "bin"))
+         (make-directory* tc-bin)
+         ;; Symlink every executable from the real bin dir so raco can
+         ;; find racket, and any helper tools it needs, in the same dir.
+         (for ([entry (in-list (directory-list real-bin-dir))])
+           (define src (build-path real-bin-dir entry))
+           (define dst (build-path tc-bin entry))
+           (when (and (file-exists? src) (not (directory-exists? src)))
+             (make-file-or-directory-link src dst)))
+         (make-file-or-directory-link tc-bin (rackup-toolchain-bin-link id))
+
+         ;; Use the real bin dir to read config.rktd (the temp dir has no
+         ;; etc/ alongside it).  This mirrors what rackup install does:
+         ;; the real-bin-dir points at the actual installation.
+         (define existing-roots
+           (read-toolchain-compiled-file-roots real-bin-dir))
+         (define env-vars
+           (list (cons "PLTCOMPILEDROOTS"
+                       (compiled-roots-value "test" "cs" existing-roots))))
+         (check-not-false (assoc "PLTCOMPILEDROOTS" env-vars)
+                          "end-to-end: PLTCOMPILEDROOTS is computed")
+
+         (with-state-lock
+           (register-toolchain! id
+                                (hash 'id id 'kind 'release 'requested-spec "test"
+                                      'resolved-version "test" 'variant 'cs
+                                      'distribution 'full 'arch "x86_64"
+                                      'platform "linux"
+                                      'env-vars (for/list ([kv (in-list env-vars)])
+                                                  (list (car kv) (cdr kv)))
+                                      'executables '("racket" "raco")
+                                      'installed-at "2026-04-01T00:00:00Z"))
+           (set-default-toolchain! id)
+           (reshim!))
+         ;; Write env.sh so the shim dispatcher picks up PLTCOMPILEDROOTS
+         (write-toolchain-env-file! id env-vars)
+
+         ;; Create a trivial source file in a scratch directory
+         (define work-dir (build-path tmp "work"))
+         (make-directory* work-dir)
+         (define src-file (build-path work-dir "hello.rkt"))
+         (write-string-file src-file "#lang racket/base\n(define x 42)\n(provide x)\n")
+
+         ;; Simulate `rackup switch <id>` by exporting RACKUP_TOOLCHAIN
+         ;; and invoking `raco make` through the rackup shim.
+         (define old-toolchain (getenv "RACKUP_TOOLCHAIN"))
+         (define old-pltcr (getenv "PLTCOMPILEDROOTS"))
+         (define old-pltaddon (getenv "PLTADDONDIR"))
+         (define old-pltcollects (getenv "PLTCOLLECTS"))
+         (dynamic-wind
+          (lambda ()
+            (putenv "RACKUP_TOOLCHAIN" id)
+            (putenv "PLTCOMPILEDROOTS" "")
+            (putenv "PLTADDONDIR" "")
+            (putenv "PLTCOLLECTS" ""))
+          (lambda ()
+            (define raco-shim (build-path (rackup-shims-dir) "raco"))
+            (check-true (link-exists? raco-shim) "raco shim exists after reshim")
+            (define-values (proc stdout stdin stderr)
+              (subprocess #f #f #f
+                          raco-shim "make" (path->string src-file)))
+            (close-output-port stdin)
+            (subprocess-wait proc)
+            (define out-str (port->string stdout))
+            (define err-str (port->string stderr))
+            (close-input-port stdout)
+            (close-input-port stderr)
+            (check-equal? (subprocess-status proc) 0
+                          (format "raco make succeeded; stdout=~a stderr=~a"
+                                  out-str err-str))
+            ;; The versioned compiled dir must exist with the .zo inside.
+            ;; On CS the machine-specific .zo lives under a machine-type
+            ;; subdir (e.g., compiled/test-cs/ta6le/), so search for any
+            ;; hello_rkt.zo beneath compiled/test-cs/.
+            (define versioned-dir (build-path work-dir "compiled" "test-cs"))
+            (check-true (directory-exists? versioned-dir)
+                        (format "compiled/test-cs exists; stderr=~a" err-str))
+            (define found-zo
+              (for/or ([p (in-directory versioned-dir)])
+                (and (equal? (path-basename-string p) "hello_rkt.zo") p)))
+            (check-not-false found-zo
+                             (format "hello_rkt.zo exists under compiled/test-cs (listing=~a)"
+                                     (with-handlers ([exn:fail? (lambda (_) "?")])
+                                       (for/list ([p (in-directory versioned-dir)]) (path->string p)))))
+            ;; And the plain compiled/ dir must NOT have picked up a
+            ;; hello_rkt.zo at the top level (Chez machine-type
+            ;; subdirs under compiled/test-cs/ are fine).
+            (define plain-zo (build-path work-dir "compiled" "hello_rkt.zo"))
+            (check-false (file-exists? plain-zo)
+                         "plain compiled/hello_rkt.zo should not exist")
+
+            ;; Startup time test: `racket -e 1` through the shim must
+            ;; not be significantly slower than without PLTCOMPILEDROOTS.
+            ;; The . fallback in PLTCOMPILEDROOTS must resolve existing
+            ;; compiled files; if it doesn't (e.g., using @ instead of .),
+            ;; Racket re-expands from source and takes ~14s instead of ~0.2s.
+            (define racket-shim (build-path (rackup-shims-dir) "racket"))
+            (define t0 (current-inexact-milliseconds))
+            (define-values (tp tp-out tp-in tp-err)
+              (subprocess #f #f #f racket-shim "-e" "1"))
+            (close-output-port tp-in)
+            (subprocess-wait tp)
+            (define tp-out-str (port->string tp-out))
+            (define tp-err-str (port->string tp-err))
+            (close-input-port tp-out)
+            (close-input-port tp-err)
+            (define elapsed-ms (- (current-inexact-milliseconds) t0))
+            (check-equal? (subprocess-status tp) 0
+                          (format "racket -e 1 through shim failed (exit ~a, stderr=~a)"
+                                  (subprocess-status tp) tp-err-str))
+            (check-true (< elapsed-ms 10000)
+                        (format "racket -e 1 through shim took ~ams (should be <10s; >10s means compiled-file fallback is broken)"
+                                (inexact->exact (round elapsed-ms)))))
+          (lambda ()
+            (if old-toolchain
+                (putenv "RACKUP_TOOLCHAIN" old-toolchain)
+                (putenv "RACKUP_TOOLCHAIN" ""))
+            (if old-pltcr
+                (putenv "PLTCOMPILEDROOTS" old-pltcr)
+                (putenv "PLTCOMPILEDROOTS" ""))
+            (if old-pltaddon
+                (putenv "PLTADDONDIR" old-pltaddon)
+                (putenv "PLTADDONDIR" ""))
+            (if old-pltcollects
+                (putenv "PLTCOLLECTS" old-pltcollects)
+                (putenv "PLTCOLLECTS" ""))))))))
+
+  ;; Direct test: setting PLTCOMPILEDROOTS with correct fallback roots
+  ;; must not cause a startup penalty.  This catches regressions like
+  ;; using @ instead of . (which breaks compiled-file resolution and
+  ;; causes a ~14s re-expansion penalty).
+  ;;
+  ;; Reads the running Racket's existing compiled-file-roots from its
+  ;; config.rktd and constructs the PLTCOMPILEDROOTS value the same way
+  ;; rackup would at install time.  This works for both in-place layouts
+  ;; (fallback = .) and FHS layouts (fallback = absolute reroot path).
+  (let ()
+    (define real-racket
+      (simplify-path (resolve-path (find-system-path 'exec-file)) #t))
+    (define real-bin-dir (let-values ([(d _ __) (split-path real-racket)]) d))
+    (when real-bin-dir
+      (define existing-roots (read-toolchain-compiled-file-roots real-bin-dir))
+      (define pcr-value (compiled-roots-value "test" "cs" existing-roots))
+      (when pcr-value
+        ;; Start from a clean environment to avoid interference from the
+        ;; test harness's RACKUP_* variables.
+        (define env (environment-variables-copy (current-environment-variables)))
+        (environment-variables-set!
+         env #"PLTCOMPILEDROOTS" (string->bytes/utf-8 pcr-value))
+        ;; Clear any test-harness vars that might confuse the child racket
+        (for ([var (in-list '(#"RACKUP_HOME" #"RACKUP_TESTING" #"RACKUP_TOOLCHAIN"
+                              #"PLTADDONDIR" #"PLTCOLLECTS" #"PLTUSERHOME"))])
+          (environment-variables-set! env var #f))
+        (define t0 (current-inexact-milliseconds))
+        (define-values (proc out in err)
+          (parameterize ([current-environment-variables env])
+            (subprocess #f #f #f real-racket "-e" "1")))
+        (close-output-port in)
+        (subprocess-wait proc)
+        (define out-str (port->string out))
+        (define err-str (port->string err))
+        (close-input-port out)
+        (close-input-port err)
+        (define elapsed-ms (- (current-inexact-milliseconds) t0))
+        (check-equal? (subprocess-status proc) 0
+                      (format "racket -e 1 with PLTCOMPILEDROOTS=~a failed (exit ~a, stderr=~a)"
+                              pcr-value (subprocess-status proc) err-str))
+        (check-true (< elapsed-ms 10000)
+                    (format "PLTCOMPILEDROOTS=~a startup took ~ams (should be <10s)"
+                            pcr-value (inexact->exact (round elapsed-ms)))))))
+
+  ;; Migration test: an installed toolchain whose meta.rktd predates
+  ;; per-toolchain PLTCOMPILEDROOTS gets the entry backfilled by
+  ;; reshim! (which runs on every state change).  Both meta.rktd and
+  ;; env.sh should be updated.
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (ensure-index!)
+     (define id "release-9.1-cs-x86_64-linux-full")
+     (define install-root (rackup-toolchain-install-dir id))
+     (define real-bin (build-path install-root "bin"))
+     (make-directory* real-bin)
+     (write-string-file (build-path real-bin "racket")
+                        "#!/usr/bin/env bash\nexit 0\n")
+     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
+
+     ;; Register the toolchain as if it had been installed by an older
+     ;; rackup: env-vars is empty (no PLTCOMPILEDROOTS).
+     (with-state-lock
+       (register-toolchain! id
+                            (hash 'id id 'kind 'release 'requested-spec "9.1"
+                                  'resolved-version "9.1" 'variant 'cs
+                                  'distribution 'full 'arch "x86_64"
+                                  'platform "linux"
+                                  'env-vars '()
+                                  'executables '("racket")
+                                  'installed-at "2026-02-01T00:00:00Z")))
+
+     ;; Sanity: nothing has PLTCOMPILEDROOTS yet
+     (check-false (assoc "PLTCOMPILEDROOTS" (toolchain-env-vars id))
+                  "before reshim: no PLTCOMPILEDROOTS in meta")
+     (check-false (file-exists? (rackup-toolchain-env-file id))
+                  "before reshim: no env.sh")
+
+     ;; Run reshim - this is what every state-changing rackup command
+     ;; (and `rackup reshim`) eventually triggers.
+     (with-state-lock (reshim!))
+
+     ;; meta.rktd now has PLTCOMPILEDROOTS
+     (define after-env-vars (toolchain-env-vars id))
+     (define pcr-pair (assoc "PLTCOMPILEDROOTS" after-env-vars))
+     (check-not-false pcr-pair "after reshim: PLTCOMPILEDROOTS backfilled in meta")
+     (check-equal? (cdr pcr-pair) "compiled/9.1-cs:."
+                   "after reshim: PLTCOMPILEDROOTS value matches version-variant")
+
+     ;; env.sh now exists with unconditional export
+     (check-true (file-exists? (rackup-toolchain-env-file id))
+                 "after reshim: env.sh written")
+     (define env-sh-content (file->string (rackup-toolchain-env-file id)))
+     (check-true (string-contains? env-sh-content "export PLTCOMPILEDROOTS='compiled/9.1-cs:.'")
+                 "after reshim: env.sh contains unconditional PLTCOMPILEDROOTS export")
+     (check-false (regexp-match? #px"if \\[ -z \"\\$\\{PLTCOMPILEDROOTS:-\\}\" \\];"
+                                 env-sh-content)
+                  "after reshim: env.sh does NOT use conditional guard")
+
+     ;; Idempotent: a second reshim does not duplicate the entry
+     (with-state-lock (reshim!))
+     (define after-env-vars-2 (toolchain-env-vars id))
+     (check-equal? (length (filter (lambda (kv) (equal? (car kv) "PLTCOMPILEDROOTS"))
+                                   after-env-vars-2))
+                   1
+                   "second reshim is idempotent")))

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -530,11 +530,11 @@
                     set -euo pipefail
                     if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
                       if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
-                        printf '9.99-local\nchez-scheme\n@|addon-dir|'
+                        printf '9.99\nchez-scheme\n@|addon-dir|'
                         exit 0
                       fi
                       case "$2" in
-                        *"(version)"*) printf '9.99-local'; exit 0 ;;
+                        *"(version)"*) printf '9.99'; exit 0 ;;
                         *"system-type 'vm"*) printf 'cs'; exit 0 ;;
                         *"find-system-path 'addon-dir"*) printf '@|addon-dir|'; exit 0 ;;
                       esac
@@ -571,6 +571,12 @@
      (check-not-false (member "scheme" (hash-ref linked-meta 'executables)))
      (check-not-false (member "petite" (hash-ref linked-meta 'executables)))
      (check-true (file-exists? (rackup-toolchain-env-file linked-id)))
+     ;; Linked toolchain env.sh should use a local-name-suffixed key so it
+     ;; doesn't share a compiled/<version>-<variant>/ dir with an
+     ;; installer-built toolchain at the same version+variant.
+     (let ([env-sh (file->string (rackup-toolchain-env-file linked-id))])
+       (check-true (string-contains? env-sh "compiled/9.99-cs-local-devsrc")
+                   "linked env.sh uses local-name-suffixed compiled dir"))
 
      (write-exe "racket"
                 @~a{#!/usr/bin/env bash
@@ -578,11 +584,11 @@
                     if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
                       # Combined probe: all three queries in one -e call
                       if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
-                        printf '9.98-local\nchez-scheme\n@|addon-dir|'
+                        printf '9.98\nchez-scheme\n@|addon-dir|'
                         exit 0
                       fi
                       case "$2" in
-                        *"(version)"*) printf '9.98-local'; exit 0 ;;
+                        *"(version)"*) printf '9.98'; exit 0 ;;
                         *"system-type 'vm"*) printf 'cs'; exit 0 ;;
                         *"find-system-path 'addon-dir"*) printf '@|addon-dir|'; exit 0 ;;
                       esac
@@ -593,7 +599,10 @@
                     printf 'ARGS=%s\n' "$*"
                     })
      (check-equal? (link-toolchain! "devsrc" (path->string src-root) '("--force")) linked-id)
-     (check-equal? (hash-ref (read-toolchain-meta linked-id) 'resolved-version) "9.98-local")
+     (check-equal? (hash-ref (read-toolchain-meta linked-id) 'resolved-version) "9.98")
+     (let ([env-sh (file->string (rackup-toolchain-env-file linked-id))])
+       (check-true (string-contains? env-sh "compiled/9.98-cs-local-devsrc")
+                   "relinked env.sh uses local-name-suffixed compiled dir"))
 
      (define shim-racket (build-path (rackup-shims-dir) "racket"))
      (define old-pltaddon (getenv "PLTADDONDIR"))
@@ -818,11 +827,11 @@
                             set -euo pipefail
                             if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
                               if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
-                                printf '9.90-local\nchez-scheme\n'
+                                printf '9.90\nchez-scheme\n'
                                 exit 0
                               fi
                               case "$2" in
-                                *"(version)"*) printf '9.90-local'; exit 0 ;;
+                                *"(version)"*) printf '9.90'; exit 0 ;;
                                 *"system-type 'vm"*) printf 'cs'; exit 0 ;;
                               esac
                             fi
@@ -2143,6 +2152,18 @@
   (check-equal? (compiled-roots-value "9.1" 'cs '("/abs/root" same))
                 "compiled/9.1-cs:/abs/root:."
                 "mixed roots: absolute + same (no duplicate .)")
+  (check-equal? (compiled-roots-value "9.1" 'cs '(same) "dev")
+                "compiled/9.1-cs-local-dev:."
+                "linked toolchain: local-name suffix distinguishes from installer")
+  (check-equal? (compiled-roots-value "9.1" 'cs '(same) #f)
+                "compiled/9.1-cs:."
+                "no local-name: no suffix")
+  (check-equal? (compiled-roots-value "9.1" 'cs '(same) "")
+                "compiled/9.1-cs:."
+                "blank local-name: no suffix")
+  (check-equal? (compiled-roots-value "9.1" 'cs '("/usr/lib/racket/compiled") "dev")
+                "compiled/9.1-cs-local-dev:/usr/lib/racket/compiled:."
+                "linked FHS layout: local-name applies to key only")
   (check-false (compiled-roots-value "9.1" 'unknown) "variant 'unknown disables")
   (check-false (compiled-roots-value "local" 'cs) "\"local\" version disables")
   (check-false (compiled-roots-value #f 'cs) "#f version disables")


### PR DESCRIPTION
## Summary

- Each toolchain exports `PLTCOMPILEDROOTS=compiled/<version>-<variant>:@` so different Racket versions and VMs don't share `.zo` files. The `@` fallback preserves access to pre-existing compiled files shipped with a full installer.
- The value is set conditionally in the per-toolchain `env.sh`, in the shell code emitted by `rackup switch`/`rackup shell`, and in `rackup run`, so a user-provided `PLTCOMPILEDROOTS` always wins.
- New `rackup remove --clean-compiled` walks the source directories of every user-scope package (catalog and linked) — enumerated via the toolchain's own `pkg/lib` rather than by parsing `raco pkg show` — and removes `compiled/<key>/` subdirectories before the toolchain is removed. This targets packages installed with `raco pkg install --link`, whose source trees persist after the toolchain is gone.
- Docs: new "Per-toolchain compiled files" section in `rackup.scrbl` covering motivation, the key format, the `@` fallback, user-override behavior, and cleanup. `IMPLEMENTATION.md` updated accordingly.

## Test plan

- [x] `raco test -y test/all.rkt` — 272 tests pass
- [x] Unit tests for `compiled-roots-value` (disabled cases, valid cases)
- [x] Unit tests for `env-var-export-line` (conditional vs unconditional)
- [x] Integration test: install-time env-var computation, conditional env.sh emission, `rackup run` user-override vs toolchain default
- [x] Integration test: `clean-toolchain-compiled-dirs!` removes versioned dirs and preserves siblings
- [x] End-to-end integration test: simulate `rackup switch <id>` by exporting `RACKUP_TOOLCHAIN`, then run `raco make` through the rackup shim against the real system racket linked into a fake toolchain, and verify the `.zo` lands under `compiled/<version>-<variant>/<machine-type>/`