### PR TITLE
Add --ref/--repo to self-upgrade, download CI binaries via gh

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -141,6 +141,10 @@ The shim dispatcher sources a per-toolchain `env.sh` file if present. For linked
 
 The env file exports only `PLTADDONDIR` when a value can be computed. Neither `PLTHOME` nor `PLTCOLLECTS` is set — the Racket binary finds its own collections via compiled-in relative paths, and `PLTHOME` is not a Racket environment variable. The one exception is old PLT Scheme installations (version <= 4.x) where the parent directory is named `plt`: these set `PLTHOME` because PLT Scheme's `bin/mzscheme` shell wrapper uses it to locate the real binary under `.bin/<archsys>/`. If `PLTADDONDIR` is still unset after sourcing (or if no env file exists), the dispatcher synthesizes a fallback value (`~/.rackup/addons/<id>`).
 
+## Post-self-upgrade reshim
+
+`cmd-self-upgrade` invokes `rackup reshim` in a subprocess after a successful update, so the freshly-installed rackup code drives the reshim. Running reshim in-process would use the old in-memory code and miss any new migration logic introduced by the upgrade.
+
 ## Shell integration
 
 `rackup init` writes a managed block into `~/.bashrc` or `~/.zshrc` delimited by marker comments (`# >>> rackup initialize >>>`). The managed block:

--- a/docs/rackup.scrbl
+++ b/docs/rackup.scrbl
@@ -443,7 +443,7 @@ keeps your current shell config unchanged.  The installer picks the
 best mode automatically (prebuilt binary if available for the current
 platform, otherwise source).
 
-@shell-block{rackup self-upgrade [--with-init] [--exe | --source]}
+@shell-block{rackup self-upgrade [--with-init] [--exe | --source] [--ref <ref> [--repo <owner>/<repo>]]}
 
 @opt-table[
   @list[@exec{--with-init}
@@ -452,12 +452,42 @@ platform, otherwise source).
         "Require a prebuilt binary (error if unavailable for this platform)."]
   @list[@exec{--source}
         "Force source installation, even if a prebuilt binary is available."]
+  @list[@exec{--ref <ref>}
+        @elem{Install rackup from the given git ref (branch, tag, or commit)
+              instead of the published release.  Useful for testing a
+              development branch or pull request.  Fetches @tt{install.sh}
+              from the target ref so any installer changes on the branch
+              are exercised too.  Custom refs do not publish prebuilt
+              binaries, so the installer falls back to source.}]
+  @list[@exec{--repo <owner>/<repo>}
+        @elem{Install rackup from a different GitHub repository (default:
+              @tt{samth/rackup}).  Combine with @tt{--ref} to test a PR
+              from a fork.}]
 ]
+
+@subsection[#:style sub-style]{Examples}
+
+@shell-block|{
+# Test the current branch of an open PR in samth/rackup
+rackup self-upgrade --ref pltcompiledroots
+
+# Test a PR from a fork
+rackup self-upgrade --repo someuser/rackup --ref my-feature
+
+# Pin to a specific commit
+rackup self-upgrade --ref a1b2c3d
+}|
+
+After a successful update, rackup automatically runs @tt{rackup reshim}
+in a subprocess so any per-toolchain migrations introduced by the new
+version (e.g., backfilling @tt{PLTCOMPILEDROOTS}) take effect for
+existing toolchains.
 
 @subsection[#:style sub-style]{Advanced}
 
 Set @tt{RACKUP_SELF_UPGRADE_INSTALL_SH} to a path or URL to override
-the install script source (useful for testing dev branches).
+the install script source (useful for local-only testing of an
+unpushed branch).
 
 @; ────────────────────────────────────────────────────────────────────
 

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -74,7 +74,7 @@
   (usage-line "init [--shell bash|zsh]" "Install/update shell integration in ~/.bashrc or ~/.zshrc.")
   (usage-line "uninstall [--dangerously-delete-without-prompting]"
               "Remove rackup, its toolchains/runtime, and shell init blocks (destructive).")
-  (usage-line "self-upgrade [--with-init] [--exe | --source]"
+  (usage-line "self-upgrade [--with-init] [--exe | --source] [--ref <ref>] [--repo <owner/repo>]"
               "Upgrade rackup's code by rerunning the installer into the current RACKUP_HOME.")
   (usage-line "runtime status|install|upgrade"
               "Manage rackup's hidden internal runtime used to run rackup itself.")
@@ -819,11 +819,22 @@
   ;; files, so deleting in-process would crash during exit.
   )
 
-(define (self-upgrade-script-source)
+(define default-rackup-repo "samth/rackup")
+
+;; Decide which install.sh URL to fetch.  When a custom --ref or --repo
+;; is specified (e.g., to test a branch/PR), fetch install.sh directly
+;; from the target branch's raw GitHub URL so any install.sh changes on
+;; the branch are exercised too.  Otherwise use the published URL.
+(define (self-upgrade-script-source #:ref [ref #f] #:repo [repo #f])
   (define env-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
-  (if (and env-override (getenv "RACKUP_TESTING"))
-      env-override
-      "https://samth.github.io/rackup/install.sh"))
+  (cond
+    [(and env-override (getenv "RACKUP_TESTING"))
+     env-override]
+    [(or ref repo)
+     (format "https://raw.githubusercontent.com/~a/~a/scripts/install.sh"
+             (or repo default-rackup-repo)
+             (or ref "main"))]
+    [else "https://samth.github.io/rackup/install.sh"]))
 
 (define (url-like? s)
   (and (string? s) (regexp-match? #px"^[a-zA-Z][a-zA-Z0-9+.-]*://" s)))
@@ -831,21 +842,32 @@
 (define (parse-self-upgrade-options rest)
   (define with-init? #f)
   (define mode #f) ; #f = auto, 'exe, 'source
+  (define ref #f)
+  (define repo #f)
   (command-line #:program "rackup self-upgrade"
                 #:argv rest
                 #:once-each
                 [("--with-init") "Also update shell init" (set! with-init? #t)]
+                [("--ref") r
+                 "Install rackup from git <ref> (branch, tag, or commit) for testing"
+                 (set! ref r)]
+                [("--repo") r
+                 "Install rackup from GitHub <owner>/<repo> (defaults to samth/rackup)"
+                 (set! repo r)]
                 #:once-any
                 [("--exe") "Require prebuilt binary" (set! mode 'exe)]
                 [("--source") "Install from source" (set! mode 'source)]
                 #:args ()
                 (void))
-  (hash 'with-init? with-init? 'mode mode))
+  (hash 'with-init? with-init? 'mode mode 'ref ref 'repo repo))
 
 (define (cmd-self-upgrade rest)
   (define opts (parse-self-upgrade-options rest))
   (define mode (hash-ref opts 'mode #f))
-  (define source (self-upgrade-script-source))
+  (define ref (hash-ref opts 'ref #f))
+  (define repo (hash-ref opts 'repo #f))
+  (define custom-source? (or ref repo))
+  (define source (self-upgrade-script-source #:ref ref #:repo repo))
 (define (parse-sha256-sidecar text)
     (for/or ([line (in-list (string-split (string-downcase text) "\n"))])
       (match (regexp-match #px"^([0-9a-f]{64})\\b" (string-trim line))
@@ -854,13 +876,20 @@
   (define script-path
     (cond
       [(url-like? source)
-       (define checksum-url (string-append source ".sha256"))
+       ;; Only attempt checksum verification for the default published
+       ;; install.sh.  Custom --ref/--repo sources fetch from raw GitHub
+       ;; and do not publish a .sha256 sidecar; skipping avoids a
+       ;; misleading warning and unnecessary HTTP round-trip.
        (define expected-sha
-         (with-handlers ([exn:fail? (lambda (e)
-                                      (eprintf "rackup: warning: could not fetch checksum from ~a: ~a\n"
-                                               checksum-url (exn-message e))
-                                      #f)])
-           (parse-sha256-sidecar (http-get-string checksum-url))))
+         (cond
+           [custom-source? #f]
+           [else
+            (define checksum-url (string-append source ".sha256"))
+            (with-handlers ([exn:fail? (lambda (e)
+                                         (eprintf "rackup: warning: could not fetch checksum from ~a: ~a\n"
+                                                  checksum-url (exn-message e))
+                                         #f)])
+              (parse-sha256-sidecar (http-get-string checksum-url)))]))
        (define p (make-temporary-file "rackup-self-upgrade-~a.sh"))
        (download-url->file source p)
        (when expected-sha
@@ -884,6 +913,8 @@
               [(eq? mode 'exe)    (list "--exe")]
               [(eq? mode 'source) (list "--source")]
               [else               null])
+            (if ref (list "--ref" ref) null)
+            (if repo (list "--repo" repo) null)
             (list "--prefix" home-str)))
   (define env (environment-variables-copy (current-environment-variables)))
   (environment-variables-set! env #"RACKUP_BOOTSTRAP_MODE" #"self-upgrade")

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -898,7 +898,19 @@
   (define sha-after
     (and (file-exists? sha-file) (file->string sha-file)))
   (when (not (equal? sha-before sha-after))
-    (displayln "rackup code upgrade complete.")))
+    (displayln "rackup code upgrade complete.")
+    ;; Run `rackup reshim` in a subprocess so the just-installed rackup
+    ;; code (not the old in-memory code) drives reshim!.  This ensures
+    ;; any migrations of per-toolchain env vars (e.g., backfilling
+    ;; PLTCOMPILEDROOTS) run with the new logic.
+    (define new-rackup (rackup-bin-entry))
+    (when (file-exists? new-rackup)
+      (with-handlers ([exn:fail?
+                       (lambda (e)
+                         (eprintf "rackup: warning: post-upgrade reshim failed: ~a\n"
+                                  (exn-message e)))])
+        (unless (system* (path->string new-rackup) "reshim")
+          (eprintf "rackup: warning: post-upgrade reshim reported failure\n"))))))
 
 (define (cmd-version rest)
   (command-line #:program "rackup version"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -423,10 +423,75 @@ if [ -z "$FROM_LOCAL" ] && [ "$FORCE_SOURCE" -eq 0 ]; then
     BINARY_BASE_URL=""
   fi
 
+  # When installing from a non-default ref/repo and no published binary
+  # URL is available, try downloading the CI-built binary artifact via
+  # the GitHub CLI (`gh`).  This lets `rackup self-upgrade --ref <branch>`
+  # install a prebuilt binary from the branch's CI run.
+  GH_BINARY_DOWNLOADED=0
+  if [ -z "$BINARY_BASE_URL" ] && [ "$REF" != "main" ] &&
+    has_prebuilt_binary "$HOST_TARGET" &&
+    command -v gh >/dev/null 2>&1; then
+    GH_ARTIFACT_NAME="rackup-exe-${BINARY_TARGET}"
+    info "Looking for CI-built binary for $BINARY_TARGET on ref '$REF'..."
+    GH_RUN_ID=""
+    GH_RUN_ID=$(gh run list \
+      --repo "$REPO" \
+      --branch "$REF" \
+      --workflow ci.yml \
+      --status completed \
+      --json databaseId,conclusion \
+      --jq '[.[] | select(.conclusion=="success")][0].databaseId' 2>/dev/null || true)
+    if [ -n "$GH_RUN_ID" ]; then
+      GH_TMPDIR="$(mktemp -d)"
+      if gh run download "$GH_RUN_ID" \
+        --repo "$REPO" \
+        --name "$GH_ARTIFACT_NAME" \
+        --dir "$GH_TMPDIR" 2>/dev/null; then
+        GH_TARBALL="$GH_TMPDIR/$BINARY_NAME"
+        if [ -f "$GH_TARBALL" ]; then
+          info "Downloaded CI binary artifact for $BINARY_TARGET."
+          mkdir -p "$TMPDIR_INSTALL/binary"
+          tar -xzmf "$GH_TARBALL" -C "$TMPDIR_INSTALL/binary"
+          BINARY_DIR="$(find "$TMPDIR_INSTALL/binary" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+          if [ -n "$BINARY_DIR" ] && [ -x "$BINARY_DIR/bin/rackup-core" ]; then
+            mkdir -p "$PREFIX"
+            mkdir -p "$PREFIX/bin" "$PREFIX/libexec"
+            cp "$BINARY_DIR/bin/rackup" "$PREFIX/bin/rackup"
+            cp "$BINARY_DIR/bin/rackup-core" "$PREFIX/bin/rackup-core"
+            chmod +x "$PREFIX/bin/rackup" "$PREFIX/bin/rackup-core"
+            if command -v xattr >/dev/null 2>&1; then
+              xattr -dr com.apple.quarantine "$PREFIX/bin" 2>/dev/null || true
+            fi
+            if [ -d "$BINARY_DIR/lib" ]; then
+              rm -rf "${PREFIX:?}/lib"
+              cp -R "$BINARY_DIR/lib" "$PREFIX/lib"
+              if command -v xattr >/dev/null 2>&1; then
+                xattr -dr com.apple.quarantine "$PREFIX/lib" 2>/dev/null || true
+              fi
+            fi
+            cp "$BINARY_DIR/libexec/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"
+            chmod +x "$PREFIX/libexec/rackup-bootstrap.sh"
+            ok "Installed prebuilt binary from CI (run $GH_RUN_ID): $PREFIX/bin/rackup"
+            INSTALLED_PREBUILT=1
+            GH_BINARY_DOWNLOADED=1
+          else
+            warn "CI binary artifact was invalid; will try other methods."
+          fi
+        fi
+      else
+        info "Could not download CI artifact; will try other methods."
+      fi
+      rm -rf "$GH_TMPDIR"
+    else
+      info "No successful CI run found for ref '$REF'; will try other methods."
+    fi
+  fi
+
   # With --exe, the binary must be available; otherwise we try and fall back.
-  if [ "$FORCE_EXE" -eq 1 ] && [ -z "$BINARY_BASE_URL" ]; then
-    warn "Error: --exe requires the default repo (samth/rackup, main branch)."
+  if [ "$FORCE_EXE" -eq 1 ] && [ -z "$BINARY_BASE_URL" ] && [ "$GH_BINARY_DOWNLOADED" -eq 0 ]; then
+    warn "Error: --exe requires a published binary or a successful CI run with 'gh' installed."
     warn "Custom --repo, --ref, or --archive-url installs do not publish prebuilt binaries."
+    warn "Either install 'gh' (GitHub CLI) to download from CI, or use --source."
     exit 1
   fi
   if [ "$FORCE_EXE" -eq 1 ] && ! has_prebuilt_binary "$HOST_TARGET"; then
@@ -435,7 +500,7 @@ if [ -z "$FROM_LOCAL" ] && [ "$FORCE_SOURCE" -eq 0 ]; then
     exit 1
   fi
 
-  if [ -n "$BINARY_BASE_URL" ] && has_prebuilt_binary "$HOST_TARGET"; then
+  if [ -n "$BINARY_BASE_URL" ] && has_prebuilt_binary "$HOST_TARGET" && [ "$GH_BINARY_DOWNLOADED" -eq 0 ]; then
     BINARY_URL="$BINARY_BASE_URL/$BINARY_NAME"
     CHECKSUM_URL="${BINARY_URL}.sha256"
     info "Downloading prebuilt binary for $HOST_TARGET..."

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -1470,6 +1470,55 @@
             (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" old-override)
             (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" ""))))))
 
+  ;; self-upgrade invokes `rackup reshim` on the freshly-installed
+  ;; binary after a successful update, so any migrations of
+  ;; per-toolchain env vars (e.g., backfilling PLTCOMPILEDROOTS) run
+  ;; with the new code.  The subprocess invocation is verified by
+  ;; placing a fake rackup binary at rackup-bin-entry that logs its
+  ;; arguments and checking the log after the upgrade.
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (ensure-index!)
+     (define reshim-log (build-path tmp "self-upgrade-reshim-args.log"))
+     ;; Fake rackup binary at ~/.rackup/bin/rackup that logs invocations
+     (make-directory* (build-path tmp "bin"))
+     (define fake-rackup (build-path tmp "bin" "rackup"))
+     (write-string-file
+      fake-rackup
+      (format
+       "#!/bin/sh\nprintf '%s\\n' \"$@\" >> ~s\nexit 0\n"
+       (path->string reshim-log)))
+     (file-or-directory-permissions fake-rackup #o755)
+
+     (define fake-installer (build-path tmp "fake-install-reshim.sh"))
+     (define sha-file (build-path tmp ".installed-sha256"))
+     (write-string-file sha-file "old-sha")
+     (write-string-file
+      fake-installer
+      (format
+       "#!/bin/sh\nset -eu\nprintf 'new-sha' > ~s\nexit 0\n"
+       (path->string sha-file)))
+     (file-or-directory-permissions fake-installer #o755)
+     (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
+     (dynamic-wind
+      (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
+      (lambda ()
+        (run-main '("self-upgrade"))
+        ;; The fake rackup binary should have been invoked with "reshim"
+        (check-true (file-exists? reshim-log)
+                    "self-upgrade invoked the new rackup binary")
+        (when (file-exists? reshim-log)
+          (define lines
+            (call-with-input-file reshim-log
+              (lambda (in) (filter (lambda (s) (not (string=? s "")))
+                                   (port->lines in)))))
+          (check-equal? lines '("reshim")
+                        "self-upgrade invoked the new rackup with 'reshim'")))
+      (lambda ()
+        (if old-override
+            (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" old-override)
+            (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" ""))))))
+
   ;; self-upgrade --exe forwards to install.sh
   (with-temp-rackup-home
    (lambda (tmp)

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -1553,6 +1553,50 @@
             (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" old-override)
             (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" ""))))))
 
+  ;; self-upgrade --ref/--repo forwards flags to install.sh
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (ensure-index!)
+     (define fake-installer (build-path tmp "fake-install-ref.sh"))
+     (define args-log (build-path tmp "self-upgrade-ref-args.log"))
+     (write-string-file
+      fake-installer
+      (format
+       "#!/bin/sh\nset -eu\n: > ~s\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> ~s; done\nexit 0\n"
+       (path->string args-log)
+       (path->string args-log)))
+     (file-or-directory-permissions fake-installer #o755)
+     (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
+     (dynamic-wind
+      (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
+      (lambda ()
+        ;; --ref only
+        (run-main '("self-upgrade" "--ref" "mybranch"))
+        (check-equal?
+         (call-with-input-file args-log
+           (lambda (in) (filter (lambda (s) (not (string=? s ""))) (port->lines in))))
+         (list "-y" "--no-init" "--ref" "mybranch" "--prefix" (path->string (rackup-home)))
+         "--ref forwarded to install.sh")
+        ;; --ref + --repo
+        (run-main '("self-upgrade" "--ref" "mybranch" "--repo" "otheruser/rackup"))
+        (check-equal?
+         (call-with-input-file args-log
+           (lambda (in) (filter (lambda (s) (not (string=? s ""))) (port->lines in))))
+         (list "-y" "--no-init" "--ref" "mybranch" "--repo" "otheruser/rackup"
+               "--prefix" (path->string (rackup-home)))
+         "--ref and --repo forwarded to install.sh")
+        ;; --ref + --source (mode flag still works)
+        (run-main '("self-upgrade" "--source" "--ref" "mybranch"))
+        (check-equal?
+         (call-with-input-file args-log
+           (lambda (in) (filter (lambda (s) (not (string=? s ""))) (port->lines in))))
+         (list "-y" "--no-init" "--source" "--ref" "mybranch" "--prefix" (path->string (rackup-home)))
+         "--ref combines with --source"))
+      (lambda ()
+        (if old-override
+            (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" old-override)
+            (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" ""))))))
+
   ;; Metadata-parts matching: "9.0-minimal" should resolve when both full and minimal exist
   (with-temp-rackup-home
    (lambda (tmp)


### PR DESCRIPTION
## Summary

- `rackup self-upgrade --ref <branch>` installs rackup from the given git ref (branch, tag, or commit) instead of the published release. Fetches `install.sh` from the target branch's raw GitHub URL so installer changes on the branch are exercised. Combine with `--repo <owner>/<repo>` for cross-fork PRs.
- When `--ref` is set and `gh` (GitHub CLI) is available, `install.sh` downloads the prebuilt binary artifact from the latest successful CI run via `gh run download`, instead of falling back to source. If `gh` is missing or the download fails, source install proceeds as before.
- `cmd-self-upgrade` runs `rackup reshim` in a subprocess after a successful update so the freshly-installed code drives the reshim (not the old in-memory code). This ensures any migrations introduced by the new version take effect immediately.

Example:
```
rackup self-upgrade --ref pltcompiledroots
```

## Test plan

- [x] `raco test -y test/all.rkt` — 246 tests pass
- [x] `shellcheck --severity=warning scripts/install.sh` — clean
- [x] `shfmt -d -i 2 -ci scripts/install.sh` — clean
- [x] Test: `--ref` and `--repo` are forwarded to install.sh subprocess args
- [x] Test: post-upgrade reshim invokes the new rackup binary with "reshim"
- [x] Test: `self-upgrade --help` shows `--ref` and `--repo` flags