### PR TITLE
Reuse main's i386 VM cache on branches to avoid 40-min rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,11 +423,15 @@ jobs:
         with:
           path: .ci-cache/native-i386-vm/downloads
           key: native-i386-vm-downloads-${{ hashFiles('test/native-i386-vm-test.sh') }}
+          restore-keys: |
+            native-i386-vm-downloads-
       - name: Restore native i386 VM guest disk cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .ci-cache/native-i386-vm/debian-i386.qcow2
           key: native-i386-vm-disk-v1-${{ hashFiles('test/native-i386-vm-test.sh', 'test/ci-native-i386-vm-smoke.sh', 'test/vm/native-i386-firstboot.sh', 'test/vm/native-i386-firstboot.service') }}
+          restore-keys: |
+            native-i386-vm-disk-v1-
       - name: Native i386 103p1 smoke
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Adds `restore-keys` to the native i386 VM download and guest disk caches so that new branches/PRs fall back to main's cached disk image instead of rebuilding Debian from scratch in emulated QEMU.

Without this, every new branch pays a ~40 minute cache-miss penalty on first CI run. With it, the branch reuses main's cached qcow2 and runs in ~2.5 minutes.

The disk image is just Debian 12 i386 + apt packages — the rackup source is mounted at boot via 9p virtfs, not baked into the image, so reusing it across branches is safe.

## Test plan

- [x] This PR's own CI run should demonstrate the fix: the 103p1 smoke job should complete in ~2-3 minutes by falling back to main's cache