### PR TITLE
Fix self-upgrade checksum: generate install.sh.sha256, error on failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ Run `test/docker-test-fresh-install.sh --help` for all options.
 
 Archive all plan documents in `docs/plans/` with dated filenames (e.g., `2026-03-13-feature-name.md`). This includes plans created during brainstorming, implementation plans, research documents, and review documents.
 
+## Verification and generation
+
+When adding code that verifies, validates, or consumes a generated
+artifact (checksums, sidecar files, metadata files, etc.), always
+verify that the artifact is actually produced by the build/deploy
+pipeline. Check the Pages build (`pages/build-pages-site.rkt`), CI
+workflows (`.github/workflows/`), and install scripts
+(`scripts/install.sh`) for the corresponding generation step. If it
+doesn't exist, add it in the same commit.
+
 ## Code ownership
 
 We own the entire project. There is no public API. Feel free to change any module's exports, signatures, or internal structure as needed — no backwards-compatibility workarounds required.

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -886,9 +886,9 @@
            [else
             (define checksum-url (string-append source ".sha256"))
             (with-handlers ([exn:fail? (lambda (e)
-                                         (eprintf "rackup: warning: could not fetch checksum from ~a: ~a\n"
-                                                  checksum-url (exn-message e))
-                                         #f)])
+                                         (rackup-error
+                                          "could not verify install script integrity.\nChecksum fetch failed: ~a\nTo skip verification, use: rackup self-upgrade --ref <ref>"
+                                          (exn-message e)))])
               (parse-sha256-sidecar (http-get-string checksum-url)))]))
        (define p (make-temporary-file "rackup-self-upgrade-~a.sh"))
        (download-url->file source p)

--- a/pages/build-pages-site.rkt
+++ b/pages/build-pages-site.rkt
@@ -94,6 +94,15 @@
      (call-with-output-file p (lambda (out) (display install-content out)) #:exists 'truncate/replace)
      (file-or-directory-permissions p #o755))
 
+   ;; Write install.sh.sha256 sidecar so `rackup self-upgrade` can
+   ;; verify the downloaded install script.
+   (define install-sh-sha256
+     (bytes->hex-string
+      (call-with-input-file (build-path out-dir "install.sh") sha256-bytes)))
+   (call-with-output-file (build-path out-dir "install.sh.sha256")
+     (lambda (out) (fprintf out "~a  install.sh\n" install-sh-sha256))
+     #:exists 'truncate/replace)
+
    ;; Generate HTML; Racket computes the install.sh checksum itself
    (make-directory* plt-web-stage)
    (run (find-executable-path "racket")


### PR DESCRIPTION
## Summary

`rackup self-upgrade` has been silently warning about a missing checksum sidecar since the checksum verification was added in 710b45b:

```
rackup: warning: could not fetch checksum from
  https://samth.github.io/rackup/install.sh.sha256: HTTP 404
```

**Root cause:** 710b45b added `.sha256` sidecar verification to `cmd-self-upgrade`, but never added the corresponding generation to `pages/build-pages-site.rkt`. The Pages build generates checksums for binary and source tarballs but not for `install.sh` itself. The stale `pages/_site/install.sh.sha256` checked into git has a hash that predates the build-time `@@RACKUP_SRC_SHA256@@` and `@@RACKUP_RUNTIME_CHECKSUMS@@` substitutions, so it never matches.

**Fixes:**
1. Generate `install.sh.sha256` during the Pages build (right after writing the transformed `install.sh`)
2. Upgrade the checksum fetch failure from a warning to an error for the default self-upgrade path — silently continuing without verification defeats the purpose

The `--ref` path (custom branch installs) continues to skip checksum verification entirely, since custom branches don't publish sidecar files.

## Test plan

- [x] `raco test -y test/all.rkt` — 246 tests pass
- [ ] After merging + Pages deploy, verify `curl -I https://samth.github.io/rackup/install.sh.sha256` returns 200
- [ ] Verify `rackup self-upgrade` no longer warns about missing checksum