### PR TITLE
Skip source checksum for custom --ref in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -594,9 +594,11 @@ if [ "$INSTALLED_PREBUILT" -eq 0 ]; then
       warn "Error: need curl or wget to download rackup sources."
       exit 1
     fi
-    if is_sha256_hex "$EXPECTED_SRC_SHA256"; then
+    if is_sha256_hex "$EXPECTED_SRC_SHA256" && [ "$REF" = "main" ]; then
       info "Verifying source download (SHA-256)..."
       verify_sha256 "$TMPDIR_INSTALL/rackup.tar.gz" "$EXPECTED_SRC_SHA256" "rackup-src.tar.gz"
+    elif [ "$REF" != "main" ]; then
+      info "Skipping source checksum for custom ref '$REF'."
     elif [ "$FORCE_SOURCE" -eq 1 ] && [ -z "$FROM_LOCAL" ] && [ -z "$ARCHIVE_URL_OVERRIDE" ]; then
       warn "Error: source checksum is not available in this copy of install.sh."
       warn "This is expected when running the repo copy directly. Use --from-local or --archive-url instead."


### PR DESCRIPTION
## Summary

The baked-in source SHA-256 in the published install.sh only matches main's source tarball. When `--ref` is set to a branch, the downloaded tarball has different content and verification fails with a checksum mismatch:

```
Error: SHA-256 checksum mismatch for rackup-src.tar.gz
  expected: e083556...
  actual:   6c7d4dc...
```

This broke `rackup self-upgrade --ref <branch> --source` and `curl ... install.sh | sh -s -- --ref <branch>`.

Fix: skip source checksum verification when `REF != main`, same as the existing skip for binary checksums with custom refs.

## Test plan

- [x] shellcheck + shfmt clean
- [ ] `curl -fsSL https://samth.github.io/rackup/install.sh | sh -s -- --ref main --source -y` still verifies checksum
- [ ] `curl -fsSL https://samth.github.io/rackup/install.sh | sh -s -- --ref pltcompiledroots --source -y` skips checksum and succeeds