### PR TITLE
Warn when switch/shell run without shell integration

### DIFF
--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -340,6 +340,13 @@
         (eprintf "rackup: executable not found: ~a\n" exe)
         (exit 1))))
 
+(define (warn-no-shell-integration! cmd-name)
+  (when (terminal-port? (current-output-port))
+    (eprintf "rackup: shell integration is not set up.\n")
+    (eprintf "Run `rackup init` first, then restart your shell.\n")
+    (eprintf "After that, `rackup ~a` will work correctly.\n" cmd-name)
+    (exit 1)))
+
 (define (cmd-shell rest)
   (ensure-index!)
   (define deactivate? #f)
@@ -350,6 +357,7 @@
                   [("--deactivate") "Deactivate shell toolchain" (set! deactivate? #t)]
                   #:args args
                   args))
+  (warn-no-shell-integration! "shell")
   (cond
     [deactivate? (display (emit-shell-deactivation))]
     [(= (length args) 1)
@@ -367,6 +375,7 @@
                   [("--unset") "Deactivate shell toolchain" (set! unset? #t)]
                   #:args args
                   args))
+  (warn-no-shell-integration! "switch")
   (cond
     [unset? (display (emit-shell-deactivation))]
     [(= (length args) 1)


### PR DESCRIPTION
## Summary
- When `rackup switch` or `rackup shell` is invoked directly (not through the shell wrapper function), raw shell code is dumped to the terminal, which is confusing
- Detect this by checking if stdout is a TTY — the shell wrapper captures stdout via `$(...)`, so it's not a TTY in normal use
- Show a helpful error message directing the user to run `rackup init` first

## Test plan
- [ ] `rackup switch <toolchain>` without shell integration shows error message
- [ ] `rackup shell <toolchain>` without shell integration shows error message
- [ ] After `rackup init && source ~/.bashrc`, both commands work normally
- [ ] `raco test -y test/all.rkt` passes