### PR TITLE
Ad-hoc sign macOS binary to prevent Killed: 9 on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,13 @@ jobs:
             toolchain_spec: "stable"
             toolchain_flags: "--distribution minimal"
             install_flags: ""
+          - name: aarch64-macosx-sequoia
+            runs_on: macos-15
+            docker_platform: ""
+            expect_mode: exe
+            toolchain_spec: "stable"
+            toolchain_flags: "--distribution minimal"
+            install_flags: ""
           # Non-exe: source fallback (x86_64 with --source flag)
           - name: x86_64-linux-source
             runs_on: ubuntu-latest
@@ -249,6 +256,17 @@ jobs:
             rackup list
             racket -e '(displayln (version))'
             raco --help >/dev/null
+          fi
+
+          # Self-upgrade: reinstall over the existing prebuilt binary.
+          # This catches code signing issues on macOS where the new binary
+          # is killed by the kernel after being downloaded and extracted.
+          if [ "${{ matrix.expect_mode }}" = "exe" ]; then
+            echo "=== Self-upgrade smoke test ==="
+            rackup self-upgrade --exe
+            rackup version
+            rackup doctor
+            echo "Self-upgrade OK"
           fi
       - name: Stop HTTP server
         if: always()

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -145,6 +145,14 @@ mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/libexec"
 cp "$DIST_DIR/bin/rackup-core" "$STAGE_DIR/bin/rackup-core"
 chmod +x "$STAGE_DIR/bin/rackup-core"
 
+# Ad-hoc sign on macOS. raco exe may invalidate the linker's automatic
+# signature by modifying the Mach-O after creation.  CI runners tolerate
+# invalid signatures, but user Macs with default security settings kill
+# the binary (Killed: 9 / SIGKILL from the kernel).
+if command -v codesign >/dev/null 2>&1; then
+  codesign --sign - --force "$STAGE_DIR/bin/rackup-core"
+fi
+
 if [ -d "$DIST_DIR/lib" ]; then
   cp -R "$DIST_DIR/lib" "$STAGE_DIR/lib"
 fi


### PR DESCRIPTION
macOS kills unsigned binaries on Apple Silicon. The rackup-core binary
built by `raco distribute` was not signed, so `rackup self-upgrade`
failed with `Killed: 9` when running the new binary for reshim.

Adds `codesign --sign - --force` after copying the binary into the
distribution staging directory. The `codesign` check is guarded so it's
a no-op on Linux.