### PR TITLE
Sign macOS binaries on macos-26 and simplify install.sh re-signing

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -20,11 +20,14 @@ jobs:
             artifact_name: aarch64-linux
             setup_racket_arch: arm64
             cross_target: ""
-          - runs_on: macos-15-intel
+          # Build macOS binaries on macOS 26 so the ad-hoc code signature
+          # is produced by the latest codesign and accepted by macOS 26+
+          # kernels (which reject signatures from older macOS versions).
+          - runs_on: macos-26-intel
             artifact_name: x86_64-macosx
             setup_racket_arch: x64
             cross_target: ""
-          - runs_on: macos-14
+          - runs_on: macos-26
             artifact_name: aarch64-macosx
             setup_racket_arch: arm64
             cross_target: ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -537,23 +537,27 @@ if [ -z "$FROM_LOCAL" ] && [ "$FORCE_SOURCE" -eq 0 ]; then
             xattr -dr com.apple.quarantine "$PREFIX/bin" 2>/dev/null || true
           fi
           # Ad-hoc sign on macOS so the binary passes code signature
-          # validation.  The build-time signature from a different macOS
-          # version may not be accepted by the user's OS (e.g., a binary
-          # signed on Sonoma is rejected by Tahoe).  Re-signing locally
-          # ensures the signature is produced by the local codesign tool.
-          if command -v codesign >/dev/null 2>&1; then
-            codesign --sign - --force "$PREFIX/bin/rackup-core" 2>/dev/null || true
+          # validation.  macOS 26 (Tahoe) can reject signatures produced
+          # by older macOS versions' codesign tool (see
+          # https://github.com/astral-sh/uv/pull/17123).  Re-signing with
+          # the user's local codesign ensures the signature is accepted.
+          if [ "$(uname -s)" = "Darwin" ]; then
+            if command -v codesign >/dev/null 2>&1; then
+              codesign --sign - --force "$PREFIX/bin/rackup-core" || {
+                warn "Error: codesign failed on $PREFIX/bin/rackup-core"
+                warn "The binary may be killed by the kernel on macOS 26+."
+              }
+            else
+              warn "Warning: codesign not found; cannot re-sign binary."
+              warn "Install Xcode Command Line Tools: xcode-select --install"
+              warn "Otherwise the binary may be killed on macOS 26+."
+            fi
           fi
           if [ -d "$BINARY_DIR/lib" ]; then
             rm -rf "${PREFIX:?}/lib"
             cp -R "$BINARY_DIR/lib" "$PREFIX/lib"
             if command -v xattr >/dev/null 2>&1; then
               xattr -dr com.apple.quarantine "$PREFIX/lib" 2>/dev/null || true
-            fi
-            # Sign any dylibs as well.
-            if command -v codesign >/dev/null 2>&1; then
-              find "$PREFIX/lib" -type f \( -name '*.dylib' -o -name '*.so' \) \
-                -exec codesign --sign - --force {} \; 2>/dev/null || true
             fi
           fi
           cp "$BINARY_DIR/libexec/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"


### PR DESCRIPTION
Two related changes to fix macOS 26 (Tahoe) rejecting CI-produced ad-hoc signatures:

1. **Move the build-exe macOS targets from macos-14/macos-15-intel to macos-26/macos-26-intel.** macOS 26's kernel rejects signatures produced by older macOS \`codesign\` versions. Signing on macos-26 produces a modern signature that macOS 26 accepts natively.

2. **Simplify the install.sh re-signing:**
   - Only sign \`rackup-core\`, not dylibs (not needed in practice — Matthias confirmed signing just the main binary fixes it, matching every other report).
   - Detect missing \`codesign\` and warn clearly rather than silently continuing.

Install-time re-sign remains as belt-and-suspenders: handles the case where the binary was built on a different macOS version than the user's, and handles local macOS 26 provenance tracking.

## Background

- macOS 26 (Tahoe) tightened AppleSystemPolicy / Gatekeeper enforcement for ad-hoc signed binaries.
- Symptom: Binary killed by kernel with \`Killed: 9\` (SIGKILL), no quarantine xattr, \`codesign -dv\` shows valid \`flags=0x2(adhoc)\`.
- Same pattern hit uv (PR #17123), Bun, Codex CLI, Claude Code CLI, cargo-dist.
- Consensus fix: re-sign at install time on the user's Mac. We do that.
- Additional improvement: sign on macOS 26 runner so the CI-produced binary format is already what macOS 26 accepts.

## Test plan
- [ ] CI green on this PR (verifies macos-26 runners work)
- [ ] Deploy Pages after merge produces a working binary on macOS 26