### PR TITLE
Re-probe linked toolchains on reshim and clean stale env-vars

### DIFF
--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -519,16 +519,16 @@
               (and (directory-exists? pkgs) (path-complete-string pkgs)))])]))
 
 (define (local-layout-env-vars layout [addon-dir #f] [version #f] [variant #f] [local-name #f])
-  (define source-root (hash-ref layout 'source-root #f))
-  ;; For source checkouts, default PLTADDONDIR to <checkout>/add-on
-  ;; (matching the plt-bin convention).
-  (define effective-addon-dir
-    (or addon-dir
-        (and source-root
-             (path->string* (build-path (string->path source-root) "add-on")))))
+  ;; If the probe gave us an addon-dir, use it.  Otherwise leave
+  ;; PLTADDONDIR unset and let the shim dispatcher fall back to its
+  ;; default (which is per-toolchain under ~/.rackup/addons/).  We
+  ;; intentionally do NOT fall back to <source-root>/add-on: that
+  ;; tends to be wrong for users whose packages live in their native
+  ;; addon-dir (e.g., ~/.local/share/racket/<install-name>/), and the
+  ;; old behavior caused silent breakage of `raco pkg` operations.
   (define addon-entry
-    (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
-        (list (cons "PLTADDONDIR" effective-addon-dir))
+    (if (and (string? addon-dir) (not (string-blank? addon-dir)))
+        (list (cons "PLTADDONDIR" addon-dir))
         null))
   (define bin-dir-str (hash-ref layout 'bin-dir #f))
   (define existing-roots
@@ -542,38 +542,6 @@
        (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
       [else null]))
   (append addon-entry compiled-roots-entry))
-
-(define (probe-local-racket-version+variant+addon-dir bin-dir env-vars)
-  (define racket-exe (build-path (string->path bin-dir) "racket"))
-  ;; Combine all three queries into a single racket invocation to avoid
-  ;; paying startup cost three times.
-  (define combined-out
-    (capture-program-output
-     #:env env-vars
-     racket-exe
-     "-e"
-     (string-append
-      "(displayln (version))"
-      "(displayln (let ([v (system-type 'vm)])"
-      "  (if (symbol? v) (symbol->string v) (format \"~a\" v))))"
-      "(display (find-system-path 'addon-dir))")))
-  (define (normalize-vm-name s)
-    (and s (not (string-blank? s))
-         (match (string-downcase s)
-           ["chez-scheme" "cs"]
-           ["racket" "bc"]
-           [v v])))
-  (define-values (version-out variant-out addon-out)
-    (if combined-out
-        (let ([lines (string-split combined-out "\n")])
-          (if (>= (length lines) 3)
-              (values (first lines) (second lines)
-                      (string-join (drop lines 2) "\n"))
-              (values #f #f #f)))
-        (values #f #f #f)))
-  (values (and version-out (not (string-blank? version-out)) version-out)
-          (normalize-vm-name variant-out)
-          (and addon-out (not (string-blank? addon-out)) addon-out)))
 
 ;; Old PLT Scheme installations (version <= 4.x) have a shell wrapper at
 ;; plt/bin/mzscheme that uses $PLTHOME to locate the real binary under
@@ -797,17 +765,17 @@
                                   (raise e))])
        (make-directory* tc-dir)
        (define extra-exes (find-local-chez-extra-executables layout))
-       (define base-env-vars (local-layout-env-vars layout))
-       ;; Restore user's saved PLTCOMPILEDROOTS (if any) for the probe.
-       ;; bin/rackup saves it as _RACKUP_ORIG_PLTCOMPILEDROOTS before
-       ;; unsetting it for the rackup-core runtime.
-       (define saved-compiled-roots (getenv "_RACKUP_ORIG_PLTCOMPILEDROOTS"))
-       (define probe-env-vars
-         (if saved-compiled-roots
-             (cons (cons "PLTCOMPILEDROOTS" saved-compiled-roots) base-env-vars)
-             base-env-vars))
+       ;; Probe the linked racket with a clean environment so
+       ;; find-system-path returns the binary's native addon-dir.
        (define-values (version* variant* addon-dir*)
-         (probe-local-racket-version+variant+addon-dir (path->string* real-bin-dir) probe-env-vars))
+         (reprobe-local-toolchain (path->string* real-bin-dir)))
+       (unless addon-dir*
+         (install-warn
+          (string-append
+           "could not probe addon-dir from ~a; PLTADDONDIR will be unset.\n"
+           "  Run `rackup link --force ~a ~a` after fixing the binary\n"
+           "  (e.g., once `raco setup` finishes) to record the correct value.")
+          (path->string* real-bin-dir) name (hash-ref layout 'input-path)))
        (define env-vars (local-layout-env-vars layout addon-dir* version* variant* name))
        (make-bin-overlay! id real-bin-dir extra-exes)
        (maybe-wrap-local-chez-extra-executables! id extra-exes layout)

--- a/libexec/rackup/shims.rkt
+++ b/libexec/rackup/shims.rkt
@@ -20,7 +20,8 @@
          current-toolchain-source
          shim-aliases-installed?
          install-shim-aliases!
-         remove-shim-aliases!)
+         remove-shim-aliases!
+         reprobe-local-toolchain)
 
 (define bootstrap-shim-names
   '("racket" "raco"))
@@ -355,29 +356,61 @@ EOF
                    (apply string-append
                           (for/list ([kv (in-list env-vars)])
                             (env-var-export-line (car kv) (cdr kv))))))
-  (write-string-file p body)
-  (file-or-directory-permissions p #o644))
+  (define existing
+    (and (file-exists? p)
+         (with-handlers ([exn:fail? (lambda (_) #f)])
+           (file->string p))))
+  (unless (equal? existing body)
+    (write-string-file p body)
+    (file-or-directory-permissions p #o644)))
 
 (define (delete-env-file! id)
   (define p (rackup-toolchain-env-file id))
   (when (file-exists? p)
     (delete-file p)))
 
+;; Re-probe a linked toolchain's racket binary.  Returns (values
+;; version variant addon-dir), all #f if the binary is missing or
+;; fails to run.  Restores _RACKUP_ORIG_PLTCOMPILEDROOTS so the probe
+;; can find its own .zo files.
+(define (reprobe-local-toolchain real-bin-dir-str)
+  (cond
+    [(not (string? real-bin-dir-str)) (values #f #f #f)]
+    [(not (file-exists? (build-path (string->path real-bin-dir-str) "racket")))
+     (values #f #f #f)]
+    [else
+     (probe-local-racket-version+variant+addon-dir
+      real-bin-dir-str (saved-pltcompiledroots-env))]))
+
+(define (saved-pltcompiledroots-env)
+  (define saved (getenv "_RACKUP_ORIG_PLTCOMPILEDROOTS"))
+  (if saved (list (cons "PLTCOMPILEDROOTS" saved)) null))
+
+(define (lookup-env-var alist key)
+  (define p (assoc key alist))
+  (and p (cadr p)))
+
+;; Re-probe the linked toolchain's racket binary on every call so
+;; addon-dir, version, and variant reflect the current source-tree
+;; state.  Returns the new env-vars list and the probed (or fallback)
+;; version+variant.  Does not fall back to <source-root>/add-on for
+;; PLTADDONDIR: that location is usually wrong for users whose
+;; packages live in their native addon-dir.
 (define (compute-local-env-vars meta)
-  (define source-root (hash-ref meta 'source-root #f))
-  (define old-env-vars (hash-ref meta 'env-vars '()))
-  (define old-addon-dir
-    (for/or ([kv (in-list old-env-vars)])
-      (and (equal? (car kv) "PLTADDONDIR") (cadr kv))))
-  (define effective-addon-dir
-    (or old-addon-dir
-        (and source-root
-             (path->string* (build-path (string->path source-root) "add-on")))))
-  (define addon-entry
-    (if (and (string? effective-addon-dir) (not (string-blank? effective-addon-dir)))
-        (list (cons "PLTADDONDIR" effective-addon-dir))
-        null))
   (define real-bin-dir-str (hash-ref meta 'real-bin-dir #f))
+  (define-values (probed-version probed-variant probed-addon)
+    (reprobe-local-toolchain real-bin-dir-str))
+  (define version (or probed-version (hash-ref meta 'resolved-version #f)))
+  (define variant
+    (or (and probed-variant (string->symbol probed-variant))
+        (hash-ref meta 'variant #f)))
+  (define addon-dir
+    (or probed-addon
+        (lookup-env-var (hash-ref meta 'env-vars '()) "PLTADDONDIR")))
+  (define addon-entry
+    (if (and (string? addon-dir) (not (string-blank? addon-dir)))
+        (list (cons "PLTADDONDIR" addon-dir))
+        null))
   (define existing-roots
     (if real-bin-dir-str
         (read-toolchain-compiled-file-roots (string->path real-bin-dir-str))
@@ -387,14 +420,13 @@ EOF
          (hash-ref meta 'requested-spec #f)))
   (define compiled-roots-entry
     (cond
-      [(compiled-roots-value (hash-ref meta 'resolved-version #f)
-                             (hash-ref meta 'variant #f)
-                             existing-roots
-                             local-name)
+      [(compiled-roots-value version variant existing-roots local-name)
        =>
        (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
       [else null]))
-  (append addon-entry compiled-roots-entry))
+  (values (append addon-entry compiled-roots-entry)
+          version
+          variant))
 
 ;; Backfill PLTCOMPILEDROOTS into an installed toolchain whose metadata
 ;; predates per-toolchain compiled roots.  Adds the entry to env-vars in
@@ -423,17 +455,26 @@ EOF
     (when (hash? meta)
       (define kind (hash-ref meta 'kind #f))
       (cond
-        ;; Local (linked) toolchains: regenerate env vars from the
-        ;; source layout (which may have changed).
+        ;; Replacing env-vars wholesale also cleans up legacy
+        ;; PLTHOME/PLTCOLLECTS entries from older rackup versions.
         [(eq? kind 'local)
-         (define env-vars (compute-local-env-vars meta))
+         (define-values (env-vars new-version new-variant)
+           (compute-local-env-vars meta))
+         (define updates
+           (filter values
+                   (list (cons 'env-vars
+                               (for/list ([kv (in-list env-vars)])
+                                 (list (car kv) (cdr kv))))
+                         (and new-version (cons 'resolved-version new-version))
+                         (and new-variant (cons 'variant new-variant)))))
+         (define new-meta
+           (for/fold ([m meta]) ([u (in-list updates)])
+             (hash-set m (car u) (cdr u))))
+         (unless (equal? new-meta meta)
+           (write-toolchain-meta! id new-meta))
          (if (pair? env-vars)
              (write-env-file! id env-vars)
              (delete-env-file! id))]
-        ;; Installed toolchains: env vars are normally computed once at
-        ;; install time and stored in meta, but backfill PLTCOMPILEDROOTS
-        ;; for toolchains that were installed by an older rackup which
-        ;; did not compute it.
         [else
          (backfill-installed-env-vars! id meta)]))))
 

--- a/libexec/rackup/util.rkt
+++ b/libexec/rackup/util.rkt
@@ -20,6 +20,7 @@
          system*/check
          shell-exe
          capture-program-output
+         probe-local-racket-version+variant+addon-dir
          current-iso8601
          path-basename-string
          http-url?
@@ -130,6 +131,40 @@
     (if (apply system* exe args)
         (string-trim (get-output-string out))
         #f)))
+
+;; Probe a local Racket binary for its version, variant ('cs/'bc), and
+;; native addon-dir.  Returns three values, any of which may be #f if
+;; the probe fails (e.g., the binary cannot run).  `env-vars` is an
+;; alist of additional environment to apply for the probe.
+(define (probe-local-racket-version+variant+addon-dir bin-dir env-vars)
+  (define racket-exe (build-path (string->path bin-dir) "racket"))
+  (define combined-out
+    (capture-program-output
+     #:env env-vars
+     racket-exe
+     "-e"
+     (string-append
+      "(displayln (version))"
+      "(displayln (let ([v (system-type 'vm)])"
+      "  (if (symbol? v) (symbol->string v) (format \"~a\" v))))"
+      "(display (find-system-path 'addon-dir))")))
+  (define (normalize-vm-name s)
+    (and s (not (string-blank? s))
+         (match (string-downcase s)
+           ["chez-scheme" "cs"]
+           ["racket" "bc"]
+           [v v])))
+  (define-values (version-out variant-out addon-out)
+    (if combined-out
+        (let ([lines (string-split combined-out "\n")])
+          (if (>= (length lines) 3)
+              (values (first lines) (second lines)
+                      (string-join (drop lines 2) "\n"))
+              (values #f #f #f)))
+        (values #f #f #f)))
+  (values (and version-out (not (string-blank? version-out)) version-out)
+          (normalize-vm-name variant-out)
+          (and addon-out (not (string-blank? addon-out)) addon-out)))
 
 (define (http-url? s)
   (and (string? s) (regexp-match? #px"(?i:^http://)" s)))

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -822,12 +822,13 @@
      (make-file-or-directory-link runtime-real-bin (rackup-runtime-bin-link runtime-id))
      (make-file-or-directory-link runtime-version-dir (rackup-runtime-current-link))
      (define racket-bin (build-path bin-dir "racket"))
+     (define fake-addon-dir (path->string (build-path tmp "fake-addon")))
      (write-string-file racket-bin
                         @~a{#!/usr/bin/env bash
                             set -euo pipefail
                             if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
                               if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
-                                printf '9.90\nchez-scheme\n'
+                                printf '9.90\nchez-scheme\n@|fake-addon-dir|'
                                 exit 0
                               fi
                               case "$2" in
@@ -2589,3 +2590,90 @@
                                    after-env-vars-2))
                    1
                    "second reshim is idempotent")))
+
+  ;; Test: reshim re-probes a linked toolchain's racket binary so
+  ;; addon-dir, version, and variant reflect the current source-tree
+  ;; state.  Old toolchains may have stale PLTHOME/PLTCOLLECTS entries
+  ;; in env-vars from an older rackup; reshim should clean them up.
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (ensure-index!)
+     (define src-root (build-path tmp "linked-src"))
+     (define plthome (build-path src-root "racket"))
+     (define bin-dir (build-path plthome "bin"))
+     (make-directory* bin-dir)
+     (make-directory* (build-path plthome "collects"))
+     (define new-addon (path->string (build-path tmp "new-addon")))
+
+     ;; Fake racket that returns NEW values on probe (different from
+     ;; what was stored in meta).
+     (write-string-file (build-path bin-dir "racket")
+                        @~a{#!/usr/bin/env bash
+                            set -euo pipefail
+                            if [[ "$#" -ge 2 && "$1" == "-e" ]]; then
+                              if [[ "$2" == *"(version)"*"system-type"*"find-system-path"* ]]; then
+                                printf '9.7.0.5\nchez-scheme\n@|new-addon|'
+                                exit 0
+                              fi
+                            fi
+                            })
+     (file-or-directory-permissions (build-path bin-dir "racket") #o755)
+
+     (define id "local-stale")
+     (define real-bin-link (rackup-toolchain-bin-link id))
+     (make-directory* (rackup-toolchain-dir id))
+     (make-file-or-directory-link bin-dir real-bin-link)
+
+     ;; Register a linked toolchain with stale meta env-vars: PLTHOME,
+     ;; PLTCOLLECTS (from before bc1d7f8), and a wrong PLTADDONDIR.
+     (with-state-lock
+       (register-toolchain! id
+                            (hash 'id id
+                                  'kind 'local
+                                  'requested-spec "stale"
+                                  'resolved-version "9.0.0.1"  ; stale
+                                  'variant 'cs                  ; ok
+                                  'distribution 'in-place
+                                  'arch "x86_64"
+                                  'platform "linux"
+                                  'source-root (path->string src-root)
+                                  'plthome (path->string plthome)
+                                  'real-bin-dir (path->string bin-dir)
+                                  'env-vars '(("PLTHOME" "/old/plthome")
+                                              ("PLTCOLLECTS" "/old/collects:/old/pkgs")
+                                              ("PLTADDONDIR" "/old/wrong/addon"))
+                                  'executables '("racket")
+                                  'installed-at "2026-03-09T00:00:00Z")))
+
+     (with-state-lock (reshim!))
+
+     ;; meta should now have the re-probed values.
+     (define new-meta (read-toolchain-meta id))
+     (check-equal? (hash-ref new-meta 'resolved-version) "9.7.0.5"
+                   "reshim re-probed version")
+     (check-equal? (hash-ref new-meta 'variant) 'cs
+                   "reshim re-probed variant")
+
+     ;; env-vars should be clean: only PLTADDONDIR + PLTCOMPILEDROOTS,
+     ;; no stale PLTHOME or PLTCOLLECTS.
+     (define new-env-vars (toolchain-env-vars id))
+     (check-false (assoc "PLTHOME" new-env-vars)
+                  "reshim cleaned stale PLTHOME from env-vars")
+     (check-false (assoc "PLTCOLLECTS" new-env-vars)
+                  "reshim cleaned stale PLTCOLLECTS from env-vars")
+     (check-equal? (cdr (assoc "PLTADDONDIR" new-env-vars)) new-addon
+                   "reshim updated PLTADDONDIR to probed value")
+     (define pcr (assoc "PLTCOMPILEDROOTS" new-env-vars))
+     (check-not-false pcr "reshim wrote PLTCOMPILEDROOTS")
+     (check-equal? (cdr pcr) "compiled/9.7.0.5-cs-local-stale:."
+                   "reshim PLTCOMPILEDROOTS uses re-probed version")
+
+     ;; env.sh should also reflect the new values.
+     (define env-sh (file->string (rackup-toolchain-env-file id)))
+     (check-true (string-contains? env-sh
+                                   (format "export PLTADDONDIR='~a'" new-addon))
+                 "env.sh has new PLTADDONDIR")
+     (check-false (string-contains? env-sh "PLTHOME")
+                  "env.sh does NOT contain stale PLTHOME")
+     (check-false (string-contains? env-sh "PLTCOLLECTS")
+                  "env.sh does NOT contain stale PLTCOLLECTS")))


### PR DESCRIPTION
Three related fixes for linked toolchain handling, motivated by a real-world failure where \`raco pkg remove ffi2\` produced "tool registered twice" warnings and reported the package as not installed:

1. **On reshim, re-probe a linked toolchain's racket binary** for current version, variant, and addon-dir. Source-tree builds change over time (rebuild, version bump), but rackup previously cached these only at link time. Stale values caused PLTCOMPILEDROOTS to point at a wrong subdirectory and PLTADDONDIR to point at a wrong addon dir.

2. **Clean stale PLTHOME and PLTCOLLECTS entries** from meta \`env-vars\`. Toolchains linked before \`bc1d7f8\` ("stop-setting-plthome-pltcollects") still carry those entries even though the env.sh has been regenerated without them. Reshim now overwrites the env-vars list wholesale with the freshly-computed values, removing legacy noise.

3. **Don't silently fall back to \`<source-root>/add-on\`** when the addon-dir probe fails. The fallback was wrong for users whose packages live in their native addon-dir (e.g., \`~/.local/share/racket/<install>/\`), causing \`raco pkg\` to silently target the wrong scope and report packages as not installed. Now: warn the user, leave PLTADDONDIR unset (the shim dispatcher's per-toolchain fallback still applies), and direct them to re-link once the binary works.

Also moves \`probe-local-racket-version+variant+addon-dir\` from \`install.rkt\` to \`util.rkt\` so \`shims.rkt\` can use it without creating a circular module dependency.

## Test plan
- [x] Existing 305 unit tests pass
- [x] Added 10 new tests for re-probe + stale-env-var cleanup
- [x] CI green