### PR TITLE
Keep old toolchain when upgrade migration fails (closes #52)

### DIFF
--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -1114,30 +1114,34 @@
                     key
                     (if (= removed 1) "y" "ies"))])]))
 
-;; Parse the output of `raco pkg show --user` into a list of package
-;; names.  The format is a header line ("Package  Checksum  Source")
-;; followed by one line per package, where the first whitespace-delimited
-;; field is the package name.  A line containing "[none]" means no
-;; packages.
+;; Parse `raco pkg show --user` into a list of package names.  Header
+;; line "Package Checksum Source"; "[none]" means empty.  Filter
+;; tokens that don't match the package-name pattern so stray bytes
+;; (terminal escape fragments, partial error messages) aren't passed
+;; to `raco pkg install`.
 (define (parse-pkg-show-output text)
   (if (or (not text) (string-blank? text))
       null
-      (let ([lines (string-split text "\n")])
-        (for/list ([line (in-list lines)]
-                   #:when (not (or (string-blank? line)
-                                   (regexp-match? #px"^\\s*Package\\b" line)
-                                   (regexp-match? #px"\\[none\\]" line))))
-          (car (string-split (string-trim line)))))))
+      (for/list ([line (in-list (string-split text "\n"))]
+                 #:unless (or (string-blank? line)
+                              (regexp-match? #px"^\\s*Package\\b" line)
+                              (regexp-match? #px"\\[none\\]" line))
+                 [tok (in-value (car (string-split (string-trim line))))]
+                 #:when (valid-pkg-name? tok))
+        tok)))
 
 ;; Migrate user-scoped packages from old-id to new-id by listing
 ;; packages from the old toolchain and installing them in the new one.
+;; Returns #t on success (or when there are no packages to migrate),
+;; #f when the migration command reported errors.
 (define (migrate-user-packages! old-id new-id)
   (install-info "Checking for user packages to migrate...")
   (define show-output (capture-raco-output old-id "pkg" "show" "--user"))
   (define pkgs (parse-pkg-show-output show-output))
   (cond
     [(null? pkgs)
-     (install-info "No user packages to migrate.")]
+     (install-info "No user packages to migrate.")
+     #t]
     [else
      (install-info "Migrating ~a user package~a: ~a"
                    (length pkgs)
@@ -1153,11 +1157,15 @@
      (define ok?
        (parameterize ([current-environment-variables env])
          (apply system* raco-exe "pkg" "install" "--auto" "--skip-installed" pkgs)))
-     (if ok?
-         (install-ok "Migrated ~a package~a."
-                     (length pkgs)
-                     (if (= (length pkgs) 1) "" "s"))
-         (install-warn "Package migration had errors. Some packages may not have been migrated."))]))
+     (cond
+       [ok?
+        (install-ok "Migrated ~a package~a."
+                    (length pkgs)
+                    (if (= (length pkgs) 1) "" "s"))
+        #t]
+       [else
+        (install-warn "Package migration had errors. Some packages may not have been migrated.")
+        #f])]))
 
 ;; Determine the install spec to use when resolving the latest version
 ;; for a toolchain's channel.  The kind field is 'release for both
@@ -1258,12 +1266,24 @@
      (define spec (meta->upgrade-spec meta))
      (define new-id (install-toolchain! spec install-opts))
      (when (and (not (equal? new-id id)) (toolchain-exists? id))
-       (migrate-user-packages! id new-id)
+       (define migrated? (migrate-user-packages! id new-id))
        (when was-default?
          (commit-state-change!
           (set-default-toolchain! new-id))
          (install-info "Default toolchain updated to ~a" new-id))
-       (remove-toolchain! id))
+       (cond
+         [migrated?
+          (remove-toolchain! id)]
+         [else
+          ;; Migration failed -- keep the old toolchain so the user can
+          ;; recover.  Don't silently delete data.
+          (install-warn
+           (string-append
+            "Keeping old toolchain ~a because migration failed.\n"
+            "  Investigate the failure above, then either:\n"
+            "    - rackup upgrade --force ~a   (retry migration)\n"
+            "    - rackup remove ~a            (discard old toolchain)")
+           id id id)]))
      new-id]
     [else
      (install-ok "  ~a is up to date (~a)" id current-version)

--- a/libexec/rackup/util.rkt
+++ b/libexec/rackup/util.rkt
@@ -30,6 +30,7 @@
          verify-installer-checksum!
          valid-toolchain-id?
          ensure-valid-toolchain-id!
+         valid-pkg-name?
          string-has-control-char?
          ensure-string-without-control-chars!
          ensure-path-without-control-chars!
@@ -210,6 +211,14 @@
   (unless (valid-toolchain-id? s)
     (rackup-error "invalid ~a: ~v" what s))
   s)
+
+;; Package name validation: positive allowlist matching Racket's pkg
+;; name rules.  Used to filter stray tokens out of `raco pkg show`
+;; output before passing them to `raco pkg install`.
+(define (valid-pkg-name? s)
+  (and (string? s)
+       (not (string-blank? s))
+       (regexp-match? #px"^[a-zA-Z0-9][a-zA-Z0-9_.+-]*$" s)))
 
 ;; Control character detection
 (define (string-has-control-char? s)

--- a/test/upgrade.rkt
+++ b/test/upgrade.rkt
@@ -32,6 +32,21 @@
     " Package  Checksum  Source\n foo  abc  cat\n")
    '("foo"))
 
+  ;; Stray tokens (terminal escape fragments, partial messages) must
+  ;; be filtered so they aren't passed to `raco pkg install`.
+  (check-equal?
+   (parse-pkg-show-output
+    (string-append
+     " Package  Checksum  Source\n"
+     " rhombus  abc123      catalog\n"
+     " [22  garbage  garbage\n"
+     " main-distribution  def456  catalog\n"))
+   '("rhombus" "main-distribution"))
+  (check-equal?
+   (parse-pkg-show-output
+    " Package  Checksum  Source\n  /usr/local/path  -  bad\n some-pkg  abc  src\n")
+   '("some-pkg"))
+
   ;; ---------------------------------------------------------------------------
   ;; meta->upgrade-spec
 


### PR DESCRIPTION
Two fixes for the upgrade-with-migration path, addressing #52:

1. When \`raco pkg install\` fails during user-package migration, **do NOT remove the old toolchain.** Previously the old toolchain was removed unconditionally, leaving the user without a working recovery path when migration produced errors. Now the old toolchain is kept and the user is told how to retry or discard:

   ```
   warning: Keeping old toolchain <id> because migration failed.
     Investigate the failure above, then either:
       - rackup upgrade --force <id>   (retry migration)
       - rackup remove <id>            (discard old toolchain)
   ```

2. **Filter obviously-invalid package names** from \`raco pkg show --user\` output. Names like \`[22\` (likely terminal escape fragments) leaked through to \`raco pkg install\`, guaranteeing migration failure. Restricted to the standard package-name pattern \`[a-zA-Z0-9][a-zA-Z0-9_.+-]*\` so stray bytes are filtered silently.

## Test plan
- [x] Existing tests pass
- [x] Added tests for the new package-name filter, including the \`[22\` case from #52