### PR TITLE
Show progress while downloading installers

### DIFF
--- a/libexec/rackup-bootstrap.sh
+++ b/libexec/rackup-bootstrap.sh
@@ -267,10 +267,19 @@ rackup_verify_runtime_installer() {
 rackup_download_to() {
   url="$1"
   out="$2"
+  mode="${3:-quiet}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$out"
+    if [ "$mode" = "progress" ] && [ -t 2 ]; then
+      curl -fL --progress-bar "$url" -o "$out"
+    else
+      curl -fsSL "$url" -o "$out"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO "$out" "$url"
+    if [ "$mode" = "progress" ] && [ -t 2 ]; then
+      wget -O "$out" "$url"
+    else
+      wget -qO "$out" "$url"
+    fi
   else
     rackup_fail "need curl or wget"
   fi
@@ -502,7 +511,7 @@ rackup_hidden_runtime_install_if_missing() {
     rackup_verify_runtime_installer "$filename" "$installer_cache"
   else
     rackup_warn "downloading hidden runtime installer: $installer_url"
-    rackup_download_to "$installer_url" "$installer_cache"
+    rackup_download_to "$installer_url" "$installer_cache" progress
     rackup_verify_runtime_installer "$filename" "$installer_cache"
     if [ "$runtime_ext" = "sh" ]; then
       chmod 0755 "$installer_cache" || true

--- a/libexec/rackup/remote.rkt
+++ b/libexec/rackup/remote.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require racket/file
+         racket/format
          racket/list
          racket/match
          racket/path
@@ -126,13 +127,19 @@
                      (url->string u)
                      (url->string target)))
      (http-open/input target (sub1 redirects-left))]
-    [(equal? code 200) in]
+    [(equal? code 200) (values in (parse-content-length headers))]
     [else
      (close-input-port in)
      (rackup-error "HTTP request failed (~a): ~a" code (url->string u))]))
 
+(define (parse-content-length headers)
+  (define v (header-ref headers "Content-Length"))
+  (and v
+       (let ([n (string->number (string-trim v))])
+         (and (exact-nonnegative-integer? n) n))))
+
 (define (http-get-string url-str)
-  (define in (http-open/input url-str))
+  (define-values (in _len) (http-open/input url-str))
   (dynamic-wind void
                 (lambda ()
                   (port->string in))
@@ -140,7 +147,7 @@
                   (close-input-port in))))
 
 (define (http-get-rktd url-str)
-  (define in (http-open/input url-str))
+  (define-values (in _len) (http-open/input url-str))
   (dynamic-wind
    void
    (lambda ()
@@ -153,16 +160,99 @@
    (lambda ()
      (close-input-port in))))
 
+(define (format-bytes n)
+  (cond
+    [(< n 1024) (format "~a B" n)]
+    [(< n (* 1024 1024)) (format "~a KB" (~r (/ n 1024.0) #:precision '(= 1)))]
+    [(< n (* 1024 1024 1024))
+     (format "~a MB" (~r (/ n 1024.0 1024.0) #:precision '(= 1)))]
+    [else (format "~a GB" (~r (/ n 1024.0 1024.0 1024.0) #:precision '(= 2)))]))
+
+(define progress-bar-width 30)
+
+;; Unicode left-block eighths: 1/8, 2/8, ..., 7/8.  Combined with U+2588
+;; (full block) for whole cells, this gives sub-cell granularity.
+(define eighth-blocks
+  (vector "" "▏" "▎" "▍" "▌" "▋" "▊" "▉"))
+(define full-block "█")
+(define empty-block "░")
+
+(define (progress-bar fraction)
+  (define f (max 0.0 (min 1.0 fraction)))
+  (define total-eighths (inexact->exact (floor (* f progress-bar-width 8))))
+  (define-values (full extra) (quotient/remainder total-eighths 8))
+  (define filled
+    (string-append (apply string-append (for/list ([_ (in-range full)]) full-block))
+                   (vector-ref eighth-blocks extra)))
+  (define filled-cells (+ full (if (positive? extra) 1 0)))
+  (define empty
+    (apply string-append
+           (for/list ([_ (in-range (- progress-bar-width filled-cells))]) empty-block)))
+  (string-append "[" filled empty "]"))
+
+(define (progress-enabled?)
+  (and (terminal-port? (current-error-port))
+       (not (getenv "RACKUP_NO_PROGRESS"))))
+
+(define (copy-port/progress in out total-len label)
+  (define show? (progress-enabled?))
+  (define err (current-error-port))
+  (define buf (make-bytes (* 64 1024)))
+  (define start-ms (current-inexact-milliseconds))
+  (define last-ms 0.0)
+  (define last-width 0)
+  (define received 0)
+  (define (render! force?)
+    (when show?
+      (define now (current-inexact-milliseconds))
+      (when (or force? (>= (- now last-ms) 200))
+        (set! last-ms now)
+        (define elapsed-s (max 0.001 (/ (- now start-ms) 1000.0)))
+        (define rate (inexact->exact (round (/ received elapsed-s))))
+        (define text
+          (cond
+            [(and total-len (positive? total-len))
+             (define frac (/ received (* 1.0 total-len)))
+             (format "  ~a  ~a%  ~a / ~a at ~a/s"
+                     (progress-bar frac)
+                     (~r (min 100.0 (* frac 100.0)) #:precision '(= 1))
+                     (format-bytes received)
+                     (format-bytes total-len)
+                     (format-bytes rate))]
+            [else
+             (format "  ~a: ~a at ~a/s"
+                     label (format-bytes received) (format-bytes rate))]))
+        (define width (string-length text))
+        (define padded
+          (if (< width last-width)
+              (string-append text (make-string (- last-width width) #\space))
+              text))
+        (set! last-width width)
+        (fprintf err "\r~a" padded)
+        (flush-output err))))
+  (let loop ()
+    (define n (read-bytes-avail! buf in))
+    (cond
+      [(eof-object? n)
+       (render! #t)
+       (when show? (newline err) (flush-output err))]
+      [else
+       (write-bytes buf out 0 n)
+       (set! received (+ received n))
+       (render! #f)
+       (loop)])))
+
 (define (download-url->file url-str dest-path)
   (make-directory* (or (path-only dest-path) "."))
-  (define in (http-open/input url-str))
+  (define-values (in content-length) (http-open/input url-str))
+  (define label (path-basename-string dest-path))
   (dynamic-wind
    void
    (lambda ()
      (call-with-output-file* dest-path
        #:exists 'truncate/replace
        (lambda (out)
-         (copy-port in out))))
+         (copy-port/progress in out content-length label))))
    (lambda ()
      (close-input-port in)))
   dest-path)
@@ -909,4 +999,8 @@
 (module+ for-testing
   (provide current-http-sendrecv-proc
            http-get-string
-           http-get-rktd))
+           http-get-rktd
+           parse-content-length
+           format-bytes
+           progress-bar
+           copy-port/progress))

--- a/test/remote.rkt
+++ b/test/remote.rkt
@@ -507,4 +507,151 @@
   (define riscv-stable-req
     (resolve-install-request "stable" #:distribution 'full #:arch "riscv64" #:platform "linux"))
   (check-equal? (hash-ref riscv-stable-req 'distribution) 'minimal)
-  (check-equal? (hash-ref riscv-stable-req 'arch) "riscv64"))
+  (check-equal? (hash-ref riscv-stable-req 'arch) "riscv64")
+
+  ;; --- Content-Length parsing -------------------------------------------
+
+  (check-false (parse-content-length null))
+  (check-false (parse-content-length (list #"X-Other: 7")))
+  (check-equal? (parse-content-length (list #"Content-Length: 1234")) 1234)
+  ;; Header-ref does case-insensitive matching.
+  (check-equal? (parse-content-length (list #"content-length: 1234")) 1234)
+  (check-equal? (parse-content-length (list #"CONTENT-LENGTH: 1234")) 1234)
+  ;; Whitespace tolerated.
+  (check-equal? (parse-content-length (list #"Content-Length:    42")) 42)
+  (check-equal? (parse-content-length (list #"Content-Length:\t42\t")) 42)
+  (check-equal? (parse-content-length (list #"Content-Length: 0")) 0)
+  ;; Headers list with multiple entries; first match wins.
+  (check-equal? (parse-content-length (list #"Server: x" #"Content-Length: 99" #"Etag: y"))
+                99)
+  ;; Garbage values reject cleanly.
+  (check-false (parse-content-length (list #"Content-Length: not-a-number")))
+  (check-false (parse-content-length (list #"Content-Length: -5")))
+  (check-false (parse-content-length (list #"Content-Length: 1.5")))
+  (check-false (parse-content-length (list #"Content-Length: ")))
+
+  ;; --- format-bytes -----------------------------------------------------
+
+  (check-equal? (format-bytes 0) "0 B")
+  (check-equal? (format-bytes 1023) "1023 B")
+  (check-equal? (format-bytes 1024) "1.0 KB")
+  (check-equal? (format-bytes (* 1024 1024)) "1.0 MB")
+  (check-equal? (format-bytes (* 1024 1024 1024)) "1.00 GB")
+  (check-regexp-match #px"^312\\.0 MB$" (format-bytes (* 312 1024 1024)))
+
+  ;; --- progress-bar -----------------------------------------------------
+
+  ;; 30-cell width, with eighth-block sub-cell granularity.
+  (let ([empty (progress-bar 0.0)]
+        [full (progress-bar 1.0)]
+        [half (progress-bar 0.5)])
+    (check-equal? empty (string-append "[" (make-string 30 #\░) "]"))
+    (check-equal? full (string-append "[" (make-string 30 #\█) "]"))
+    ;; Half == 15 full blocks then 15 empty blocks.
+    (check-equal? half
+                  (string-append "["
+                                 (make-string 15 #\█)
+                                 (make-string 15 #\░)
+                                 "]")))
+  ;; Out-of-range fractions are clamped.
+  (check-equal? (progress-bar -0.5) (progress-bar 0.0))
+  (check-equal? (progress-bar 1.5) (progress-bar 1.0))
+  ;; Sub-cell granularity: 1/240 fraction → first eighth-block visible.
+  (let ([s (progress-bar (/ 1.0 (* 30 8)))])
+    (check-true (regexp-match? #px"^\\[▏" s)
+                "1/240 should render the 1/8 left-block character"))
+
+  ;; --- copy-port/progress: byte-perfect round-trip ----------------------
+
+  (define (collect-bytes payload total-len)
+    ;; Run copy-port/progress with a custom input port and verify the
+    ;; output bytes match payload exactly.
+    (define in (open-input-bytes payload))
+    (define out (open-output-bytes))
+    (copy-port/progress in out total-len "test")
+    (get-output-bytes out))
+
+  ;; Empty body.
+  (check-equal? (collect-bytes #"" 0) #"")
+  (check-equal? (collect-bytes #"" #f) #"")
+  ;; Body smaller than buffer.
+  (check-equal? (collect-bytes #"hello" 5) #"hello")
+  (check-equal? (collect-bytes #"hello" #f) #"hello")
+  ;; Body whose length disagrees with declared Content-Length: bytes are
+  ;; still copied verbatim (the percentage display clamps but data flow
+  ;; is unaffected).
+  (check-equal? (collect-bytes #"hello" 999) #"hello")
+  (check-equal? (collect-bytes #"hello" 2) #"hello")
+  ;; Body larger than the 64KB internal buffer: forces multiple
+  ;; read-bytes-avail!/write-bytes iterations of the copy loop.
+  (let ([big (make-bytes (* 200 1024) 65)])
+    (check-equal? (collect-bytes big (bytes-length big)) big))
+  ;; Body with embedded NUL and high-bit bytes: ensure no encoding
+  ;; conversion sneaks in along the byte path.
+  (let ([raw (apply bytes-append
+                    (for/list ([i (in-range 256)]) (bytes i)))])
+    (check-equal? (collect-bytes raw (bytes-length raw)) raw))
+
+  ;; --- copy-port/progress: degenerate ports -----------------------------
+
+  ;; Port that returns at most one byte per read-bytes-avail! call.
+  ;; The copy loop must accumulate every byte without dropping any.
+  (define (make-one-byte-port src)
+    (define i 0)
+    (define len (bytes-length src))
+    (make-input-port 'one-byte
+                     (lambda (buf)
+                       (cond
+                         [(= i len) eof]
+                         [else
+                          (bytes-set! buf 0 (bytes-ref src i))
+                          (set! i (add1 i))
+                          1]))
+                     #f
+                     void))
+  (let* ([payload (bytes-append (make-bytes 4096 88)
+                                #"--MIDDLE--"
+                                (make-bytes 4096 89))]
+         [in (make-one-byte-port payload)]
+         [out (open-output-bytes)])
+    (copy-port/progress in out (bytes-length payload) "drip")
+    (check-equal? (get-output-bytes out) payload
+                  "one-byte-at-a-time port must produce identical bytes"))
+
+  ;; --- download-url->file: round-trip via mocked sendrecv ---------------
+
+  (let ([payload (bytes-append (make-bytes (* 100 1024) 70)
+                               #"\0\1\2\3\4\5"
+                               (make-bytes (* 50 1024) 71))]
+        [in #f]
+        [dest #f])
+    (set! in (open-input-bytes payload))
+    (set! dest (make-temporary-file "rackup-download-roundtrip-~a" #f tmp-root))
+    (parameterize ([current-http-sendrecv-proc
+                    (make-keyword-procedure
+                     (lambda (_kws _kw-args . _args)
+                       (values "HTTP/1.1 200 OK"
+                               (list (string->bytes/utf-8
+                                      (format "Content-Length: ~a" (bytes-length payload))))
+                               in)))])
+      (define returned (download-url->file "http://example.invalid/file" dest))
+      (check-equal? returned dest)
+      (check-equal? (file->bytes dest) payload
+                    "downloaded file must contain exactly the response body"))
+    (check-true (port-closed? in)
+                "input port must be closed after a successful download")
+    (delete-file dest))
+
+  ;; download-url->file when the response has no Content-Length: still
+  ;; copies verbatim and closes the input port.
+  (let* ([payload #"abcdefghij"]
+         [in (open-input-bytes payload)]
+         [dest (make-temporary-file "rackup-download-no-clen-~a" #f tmp-root)])
+    (parameterize ([current-http-sendrecv-proc
+                    (make-keyword-procedure
+                     (lambda (_kws _kw-args . _args)
+                       (values "HTTP/1.1 200 OK" null in)))])
+      (download-url->file "http://example.invalid/file" dest))
+    (check-equal? (file->bytes dest) payload)
+    (check-true (port-closed? in))
+    (delete-file dest)))


### PR DESCRIPTION
Large installer downloads (often 100-300+ MB) previously gave no
feedback while running, leaving users uncertain whether anything was
happening. Add a single-line progress indicator for the big downloads:

- In Racket, replace the unbounded copy-port in download-url->file with
  a chunked copy that prints "<file>: <got>/<total> (<pct>%) at <rate>"
  to stderr, parsed from the Content-Length header. Output goes to
  stderr only when stderr is a TTY; can be suppressed with
  RACKUP_NO_PROGRESS.

- In rackup-bootstrap.sh, add a 'progress' mode to rackup_download_to
  that uses curl --progress-bar (or wget without -q) when stderr is a
  TTY. Apply it to the hidden-runtime installer download. Small fetches
  (version.txt, table.rktd, install.sh sidecars) stay silent.

http-open/input now returns (values in content-length); the two
callers that don't care discard the second value.