### PR TITLE
Support installing toolchains to a custom prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
         run: raco pkg install --auto recspecs
       - name: Test (includes local-link unit coverage)
         shell: bash
-        run: TMPDIR=/tmp raco test test/copy-filtered-tree.rkt test/rktd-io.rkt test/util.rkt test/versioning.rkt test/remote.rkt test/platform-targets.rkt test/state-shims.rkt test/uninstall.rkt test/rebuild.rkt
+        run: TMPDIR=/tmp raco test test/copy-filtered-tree.rkt test/install-prefix.rkt test/rktd-io.rkt test/util.rkt test/versioning.rkt test/remote.rkt test/platform-targets.rkt test/state-shims.rkt test/uninstall.rkt test/rebuild.rkt
 
   docker-e2e-linux-distros:
     name: "Docker E2E (native ${{ matrix.arch_name }} / ${{ matrix.base_image }})"

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -114,6 +114,12 @@ The default toolchain is also stored separately in `~/.rackup/state/default-tool
 
 Each toolchain has a `meta.rktd` file under `~/.rackup/toolchains/<id>/` recording its kind, version, variant, architecture, platform, installer URL, install timestamp, and other details. This file is written once at install time and not modified afterward.
 
+### Toolchain install prefix (`--prefix`)
+
+By default the on-disk directory for a toolchain is the same as its logical location, `~/.rackup/toolchains/<id>/`. With `rackup install --prefix <path>` (or `RACKUP_TOOLCHAIN_PREFIX=<path>`), the install routine places the real directory at `<path>/<id>/` and creates `~/.rackup/toolchains/<id>` as an absolute symlink pointing to it. All path-derived helpers in `paths.rkt` continue to return the symlinked location, so the rest of the codebase is oblivious to the indirection — the OS resolves through the link.
+
+The prefix is recorded in `meta.rktd` under `'toolchain-prefix` so `rackup upgrade` reinstalls in the same prefix without the user having to repeat the flag. `delete-toolchain-dir!` (in `install.rkt`) detects the symlink form and cleans up both the link target and the link itself; `toolchain-dir-occupied?` treats a dangling link as occupied so `--force` can recover when the prefix target is gone (e.g., after `/tmp` is wiped on reboot). `rackup doctor` annotates each toolchain with its prefix or flags broken links.
+
 ### Atomic file writes
 
 `rktd-io.rkt` provides `write-rktd-file` and `write-string-file` which write to a temporary file in the same directory and then `rename-file-or-directory` atomically into place. This prevents partial writes from corrupting state files if rackup is interrupted.

--- a/docs/rackup.scrbl
+++ b/docs/rackup.scrbl
@@ -84,6 +84,17 @@ The @tt{<spec>} argument selects which toolchain to install:
         "Redownload installer instead of using cache."]
   @list[@exec{--installer-ext sh|tgz|dmg}
         "Force installer extension (default: platform-dependent)."]
+  @list[@exec{--prefix <path>}
+        @elem{Install the toolchain under @tt{<path>/<id>/} on disk
+              and create @tt{~/.rackup/toolchains/<id>} as a symlink
+              to it.  Useful when @tt{~/.rackup} lives on slow or
+              networked storage; point @tt{--prefix} at a local
+              filesystem (e.g.@literal{ }@tt{/tmp/rackup-tc}) to keep
+              compilation fast.  Falls back to the
+              @tt{RACKUP_TOOLCHAIN_PREFIX} environment variable when
+              the flag is omitted.  The choice is persisted in the
+              toolchain's metadata so @tt{rackup upgrade} reinstalls
+              under the same prefix.}]
   @list[@exec{--quiet}
         "Show minimal output (errors + final result lines)."]
   @list[@exec{--verbose}
@@ -97,6 +108,7 @@ rackup install stable
 rackup install 8.18 --variant cs
 rackup install snapshot --snapshot-site utah
 rackup install pre-release --distribution minimal --set-default
+rackup install stable --prefix /tmp/rackup-tc
 }|
 
 @; ────────────────────────────────────────────────────────────────────

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -31,7 +31,9 @@
          commit-state-change!
          detect-local-source-layout
          finalize-local-toolchain!
-         local-toolchain-id)
+         local-toolchain-id
+         delete-toolchain-dir!
+         resolve-toolchain-prefix)
 
 ;; Acquire the state lock, run body, then reshim to keep shims
 ;; consistent with the new state.
@@ -75,6 +77,33 @@
       (string-append (string-join (take lines max-lines) "\n")
                      "\n..."
                      (format "\n[truncated to first ~a lines]" max-lines))))
+
+;; Remove a toolchain directory whether it's a real directory or a
+;; --prefix symlink (working or dangling).  Idempotent: a no-op when
+;; nothing exists at tc-dir.  We can't just call delete-directory/files
+;; because Racket deletes the link only, leaving the prefix target.
+(define (delete-toolchain-dir! tc-dir)
+  (cond
+    [(link-exists? tc-dir)
+     (define target (resolve-path tc-dir))
+     (when (directory-exists? target)
+       (delete-directory/files target))
+     (delete-file tc-dir)]
+    [(directory-exists? tc-dir)
+     (delete-directory/files tc-dir)]))
+
+;; Validate and absolutize a --prefix value (or RACKUP_TOOLCHAIN_PREFIX).
+;; Returns an absolute path with ~ expanded, or #f when missing/blank.
+(define (resolve-toolchain-prefix raw)
+  (and raw (not (and (string? raw) (string-blank? raw)))
+       (let ([p (path->complete-path
+                 (expand-user-path
+                  (if (path? raw) raw (string->path raw))))])
+         (ensure-path-without-control-chars! p "toolchain prefix")
+         (when (and (file-exists? p) (not (directory-exists? p)))
+           (rackup-error "toolchain prefix exists and is not a directory: ~a"
+                         (path->string* p)))
+         p)))
 
 (define (installer-cache-file installer-url)
   (build-path (rackup-download-cache-dir)
@@ -575,7 +604,7 @@
       [else null]))
   (append plthome-entry compiled-roots-entry))
 
-(define (toolchain-meta request id real-bin-dir executables [env-vars null])
+(define (toolchain-meta request id real-bin-dir executables [env-vars null] [prefix #f])
   (hash 'id
         id
         'kind
@@ -608,6 +637,8 @@
         (path->string* (rackup-toolchain-bin-link id))
         'real-bin-dir
         (path->string* real-bin-dir)
+        'toolchain-prefix
+        (and prefix (path->string* prefix))
         'env-vars
         (for/list ([kv (in-list env-vars)])
           (list (car kv) (cdr kv)))
@@ -637,6 +668,7 @@
   (define no-cache? #f)
   (define verbosity 'normal)
   (define installer-ext #f)
+  (define prefix-arg #f)
   (command-line #:program "rackup install"
                 #:argv opts
                 #:once-each [("--variant") v "VM variant" (set! variant v)]
@@ -649,11 +681,17 @@
                 [("--force") "Reinstall existing canonical toolchain" (set! force? #t)]
                 [("--no-cache") "Redownload installer instead of using cache" (set! no-cache? #t)]
                 [("--installer-ext") e "Force installer extension (sh, tgz, dmg)" (set! installer-ext e)]
+                [("--prefix") p
+                              "Install under <p>/<id>/ via symlink (default: $RACKUP_TOOLCHAIN_PREFIX)"
+                              (set! prefix-arg p)]
                 #:once-any
                 [("--quiet") "Show minimal install output" (set! verbosity 'quiet)]
                 [("--verbose") "Show detailed installer URL/path output" (set! verbosity 'verbose)]
                 #:args ()
                 (void))
+  (define prefix
+    (resolve-toolchain-prefix
+     (or prefix-arg (getenv "RACKUP_TOOLCHAIN_PREFIX"))))
   (hash 'variant
         variant
         'distribution
@@ -673,7 +711,9 @@
         'verbosity
         verbosity
         'installer-ext
-        installer-ext))
+        installer-ext
+        'prefix
+        prefix))
 
 (define (parse-link-options opts)
   (define set-default? #f)
@@ -748,9 +788,9 @@
   (define parsed-opts (parse-link-options opts))
   (define id (local-toolchain-id name))
   (define tc-dir (rackup-toolchain-dir id))
-  (when (and (directory-exists? tc-dir) (hash-ref parsed-opts 'force? #f))
-    (delete-directory/files tc-dir)
-    (when (directory-exists? tc-dir)
+  (when (hash-ref parsed-opts 'force? #f)
+    (delete-toolchain-dir! tc-dir)
+    (when (or (link-exists? tc-dir) (directory-exists? tc-dir))
       (rackup-error "failed to remove existing toolchain before relink: ~a" id)))
   (define layout (detect-local-source-layout local-path))
   (define real-bin-dir (string->path (hash-ref layout 'bin-dir)))
@@ -759,12 +799,11 @@
     (rackup-error "linked toolchain does not contain an executable racket binary at ~a"
                   (path->string* racket-exe)))
   (cond
-    [(directory-exists? tc-dir)
+    [(or (link-exists? tc-dir) (directory-exists? tc-dir))
      (rackup-error "toolchain already exists: ~a (use --force to relink)" id)]
     [else
      (with-handlers ([exn:fail? (lambda (e)
-                                  (when (directory-exists? tc-dir)
-                                    (delete-directory/files tc-dir))
+                                  (delete-toolchain-dir! tc-dir)
                                   (raise e))])
        (make-directory* tc-dir)
        (finalize-local-toolchain! id name layout
@@ -887,17 +926,21 @@
   (define id (canonical-id-for-request request))
   (define tc-dir (rackup-toolchain-dir id))
   (define install-root (rackup-toolchain-install-dir id))
+  (define prefix (hash-ref parsed-opts 'prefix #f))
   (parameterize ([current-install-verbosity (hash-ref parsed-opts 'verbosity 'normal)])
     (define default-before (get-default-toolchain))
     (define explicit-default? (hash-ref parsed-opts 'set-default? #f))
-    (when (and (directory-exists? tc-dir) (hash-ref parsed-opts 'force? #f))
-      (delete-directory/files tc-dir)
-      (when (directory-exists? tc-dir)
+    (when (hash-ref parsed-opts 'force? #f)
+      (delete-toolchain-dir! tc-dir)
+      (when (or (link-exists? tc-dir) (directory-exists? tc-dir))
         (rackup-error "failed to remove existing toolchain before reinstall: ~a" id)))
-    ;; A directory without an index entry is a ghost from a prior interrupted
-    ;; install.  Clean it up so the install can proceed.
+    ;; A dangling --prefix symlink (target wiped, e.g., /tmp cleared) or a
+    ;; ghost dir from an interrupted install would block the reinstall;
+    ;; clean either up here.
+    (when (and (link-exists? tc-dir) (not (directory-exists? tc-dir)))
+      (delete-toolchain-dir! tc-dir))
     (when (and (directory-exists? tc-dir) (not (toolchain-exists? id)))
-      (delete-directory/files tc-dir))
+      (delete-toolchain-dir! tc-dir))
     (cond
       [(directory-exists? tc-dir)
        (install-ok "Already installed: ~a" id)
@@ -921,10 +964,22 @@
        (preflight-request-install! request installer-ext)
        (with-handlers ([(lambda (e) (or (exn:fail? e) (exn:break? e)))
                         (lambda (e)
-                                    (when (directory-exists? tc-dir)
-                                      (delete-directory/files tc-dir))
-                                    (raise e))])
-         (make-directory* tc-dir)
+                          (delete-toolchain-dir! tc-dir)
+                          (raise e))])
+         (cond
+           [prefix
+            (define real (build-path prefix id))
+            (when (or (link-exists? real) (directory-exists? real))
+              (rackup-error
+               (string-append
+                "refusing to install ~a into existing prefix path: ~a\n"
+                "Remove or relocate the existing path before reinstalling.")
+               id (path->string* real)))
+            (install-info "Installing into prefix ~a" (path->string* prefix))
+            (make-directory* real)
+            (make-file-or-directory-link real tc-dir)]
+           [else
+            (make-directory* tc-dir)])
          (cond
            [(equal? installer-ext "sh")
             (run-linux-installer! installer-path
@@ -945,7 +1000,7 @@
              (delete-toolchain-env-file! id))
          (ensure-toolchain-addon-dir! id)
          (define executables (enumerate-toolchain-executables real-bin-dir))
-         (define meta (toolchain-meta request id real-bin-dir executables env-vars))
+         (define meta (toolchain-meta request id real-bin-dir executables env-vars prefix))
          (commit-state-change!
           (register-toolchain! id meta)
           (when explicit-default?
@@ -962,10 +1017,8 @@
     (rackup-error "toolchain not installed: ~a" id))
   (when clean-compiled?
     (clean-toolchain-compiled-dirs! id))
-  (define tc-dir (rackup-toolchain-dir id))
   (define addon (rackup-addon-dir id))
-  (when (directory-exists? tc-dir)
-    (delete-directory/files tc-dir))
+  (delete-toolchain-dir! (rackup-toolchain-dir id))
   (when (directory-exists? addon)
     (delete-directory/files addon))
   (commit-state-change!
@@ -1254,6 +1307,10 @@
           (if (and s (not (eq? s 'auto)))
               (list "--snapshot-site" (format "~a" s))
               null))
+        (let ([p (hash-ref meta 'toolchain-prefix #f)])
+          (if (and (string? p) (not (string-blank? p)))
+              (list "--prefix" p)
+              null))
         (if force? (list "--force") null)
         (if no-cache? (list "--no-cache") null)))
      (define spec (meta->upgrade-spec meta))
@@ -1317,13 +1374,24 @@
   (for ([kv findings])
     (printf "~a: ~a\n" (ansi "1" (format "~a" (car kv))) (cdr kv)))
   (for ([id ids])
-    (define m (read-toolchain-meta id))
-    (printf "toolchain ~a => ~a\n"
+    (define m (or (read-toolchain-meta id) (hash)))
+    (define tc-dir (rackup-toolchain-dir id))
+    (define prefix-note
+      (cond
+        [(not (link-exists? tc-dir)) ""]
+        [(directory-exists? tc-dir)
+         (format " ~a" (ansi "36" (format "(prefix -> ~a)"
+                                          (path->string* (resolve-path tc-dir)))))]
+        [else
+         (format " ~a" (ansi "31" (format "(BROKEN: link target missing -> ~a)"
+                                          (path->string* (resolve-path tc-dir)))))]))
+    (printf "toolchain ~a => ~a~a\n"
             id
             (ansi "90" (format "(~a, ~a, ~a)"
                                 (hash-ref m 'resolved-version #f)
                                 (hash-ref m 'variant #f)
-                                (hash-ref m 'distribution #f))))))
+                                (hash-ref m 'distribution #f)))
+            prefix-note)))
 
 (module+ for-testing
   (provide detect-bin-dir

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -135,7 +135,7 @@
   (with-handlers ([exn:fail? (lambda (_) null)])
     (if (directory-exists? (rackup-toolchains-dir))
         (sort (for/list ([p (in-list (directory-list (rackup-toolchains-dir) #:build? #t))]
-                         #:when (directory-exists? p))
+                         #:when (or (directory-exists? p) (link-exists? p)))
                 (path-basename-string p))
               string<?)
         null)))
@@ -163,9 +163,9 @@
 (define (remove-orphan-toolchain! id)
   (define tc-dir (rackup-toolchain-dir id))
   (define addon (rackup-addon-dir id))
-  (unless (directory-exists? tc-dir)
+  (unless (or (link-exists? tc-dir) (directory-exists? tc-dir))
     (rackup-error "orphan toolchain directory not found: ~a" id))
-  (delete-directory/files tc-dir)
+  (delete-toolchain-dir! tc-dir)
   (when (directory-exists? addon)
     (delete-directory/files addon))
   (with-handlers ([exn:fail? (lambda (_) (void))])
@@ -596,7 +596,7 @@
                   #:program "rackup install"
                   #:argv (reorder-args rest
                                        '("--variant" "--distribution" "--snapshot-site"
-                                         "--arch" "--installer-ext"))
+                                         "--arch" "--installer-ext" "--prefix"))
                   #:once-each
                   [("--variant") v "cs|bc - Override VM variant" (flag! "--variant" v)]
                   [("--distribution") d "full|minimal - Distribution type" (flag! "--distribution" d)]
@@ -608,6 +608,9 @@
                   [("--no-cache") "Redownload installer" (flag! "--no-cache")]
                   [("--installer-ext") e "sh|tgz|dmg - Force installer extension"
                    (flag! "--installer-ext" e)]
+                  [("--prefix") p
+                   "Install toolchain under <p>/<id>/ via symlink (e.g., /tmp/rackup-tc on fast disk)"
+                   (flag! "--prefix" p)]
                   [("--short-aliases") "Install short aliases: r (racket), dr (drracket)"
                    (set! short-aliases? #t)]
                   #:once-any

--- a/test/all.rkt
+++ b/test/all.rkt
@@ -2,6 +2,7 @@
 
 (require rackunit/text-ui
          "copy-filtered-tree.rkt"
+         "install-prefix.rkt"
          "rebuild.rkt"
          "rktd-io.rkt"
          "shell-completion.rkt"

--- a/test/install-prefix.rkt
+++ b/test/install-prefix.rkt
@@ -1,0 +1,135 @@
+#lang racket/base
+
+(require rackunit
+         racket/file
+         racket/path
+         "../libexec/rackup/install.rkt"
+         "../libexec/rackup/paths.rkt"
+         "../libexec/rackup/rktd-io.rkt"
+         "../libexec/rackup/state.rkt"
+         "../libexec/rackup/state-lock.rkt"
+         "../libexec/rackup/util.rkt")
+
+(define (with-temp-home proc)
+  (define tmp (make-temporary-file "rackup-prefix-test~a" 'directory))
+  (define old-home (getenv "RACKUP_HOME"))
+  (define old-testing (getenv "RACKUP_TESTING"))
+  (dynamic-wind (lambda ()
+                  (putenv "RACKUP_HOME" (path->string tmp))
+                  (putenv "RACKUP_TESTING" "1"))
+                (lambda () (proc tmp))
+                (lambda ()
+                  (if old-home
+                      (putenv "RACKUP_HOME" old-home)
+                      (putenv "RACKUP_HOME" ""))
+                  (if old-testing
+                      (putenv "RACKUP_TESTING" old-testing)
+                      (putenv "RACKUP_TESTING" ""))
+                  (delete-directory/files tmp #:must-exist? #f))))
+
+(module+ test
+  ;; resolve-toolchain-prefix
+  (check-false (resolve-toolchain-prefix #f))
+  (check-false (resolve-toolchain-prefix ""))
+  (check-false (resolve-toolchain-prefix "   "))
+  (check-true (absolute-path? (resolve-toolchain-prefix "/tmp/rackup-tc")))
+  (check-equal? (path->string (resolve-toolchain-prefix "/tmp/rackup-tc"))
+                "/tmp/rackup-tc")
+  (check-exn #px"control characters"
+             (lambda () (resolve-toolchain-prefix "/tmp/foo\nbar")))
+  ;; A path that exists but is a regular file is rejected.
+  (define tmp-file (make-temporary-file "rackup-prefix-file-~a"))
+  (dynamic-wind void
+                (lambda ()
+                  (check-exn #px"prefix exists and is not a directory"
+                             (lambda () (resolve-toolchain-prefix
+                                         (path->string tmp-file)))))
+                (lambda () (delete-file tmp-file)))
+
+  ;; delete-toolchain-dir! for plain dirs
+  (with-temp-home
+   (lambda (_)
+     (ensure-rackup-layout!)
+     (define tc-dir (rackup-toolchain-dir "fake-plain"))
+     (delete-toolchain-dir! tc-dir)             ; idempotent no-op
+     (make-directory* tc-dir)
+     (write-string-file (build-path tc-dir "marker") "x")
+     (delete-toolchain-dir! tc-dir)
+     (check-false (directory-exists? tc-dir))))
+
+  ;; delete-toolchain-dir! for --prefix symlinks: cleans up both the
+  ;; link and the prefix target.
+  (with-temp-home
+   (lambda (tmp-home)
+     (ensure-rackup-layout!)
+     (define tc-dir (rackup-toolchain-dir "fake-prefixed"))
+     (define real (build-path tmp-home "alt-prefix" "fake-prefixed"))
+     (make-directory* real)
+     (write-string-file (build-path real "marker") "y")
+     (make-file-or-directory-link real tc-dir)
+
+     (delete-toolchain-dir! tc-dir)
+
+     (check-false (link-exists? tc-dir))
+     (check-false (directory-exists? real)
+                  "delete-toolchain-dir! should remove the prefix target too")))
+
+  ;; A dangling --prefix symlink (target wiped, e.g., /tmp cleared):
+  ;; delete-toolchain-dir! removes the dangling link without error.
+  (with-temp-home
+   (lambda (tmp-home)
+     (ensure-rackup-layout!)
+     (define tc-dir (rackup-toolchain-dir "fake-dangling"))
+     (define real (build-path tmp-home "alt-prefix" "fake-dangling"))
+     (make-directory* real)
+     (make-file-or-directory-link real tc-dir)
+     (delete-directory/files (build-path tmp-home "alt-prefix"))
+
+     (check-false (directory-exists? tc-dir))
+     (check-true (link-exists? tc-dir))
+
+     (delete-toolchain-dir! tc-dir)
+     (check-false (link-exists? tc-dir))))
+
+  ;; remove-toolchain! works on a registered --prefix-installed
+  ;; toolchain: deletes the link, the link target, and the addon dir,
+  ;; and unregisters from the index.
+  (with-temp-home
+   (lambda (tmp-home)
+     (ensure-rackup-layout!)
+     (ensure-index!)
+     (define id "release-9.1-cs-x86_64-linux-full")
+     (define tc-dir (rackup-toolchain-dir id))
+     (define prefix (build-path tmp-home "alt-prefix"))
+     (define real (build-path prefix id))
+     (define real-bin (build-path real "install" "bin"))
+     (make-directory* real-bin)
+     (write-string-file (build-path real-bin "racket") "#!/bin/sh\nexit 0\n")
+     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (make-file-or-directory-link real tc-dir)
+     (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
+     (define addon (rackup-addon-dir id))
+     (make-directory* addon)
+     (with-state-lock
+      (register-toolchain!
+       id
+       (hash 'id id
+             'kind 'release
+             'requested-spec "stable"
+             'resolved-version "9.1"
+             'variant 'cs
+             'distribution 'full
+             'arch "x86_64"
+             'platform "linux"
+             'toolchain-prefix (path->string prefix)
+             'executables '("racket")
+             'installed-at "2026-05-01T00:00:00Z")))
+
+     (parameterize ([current-output-port (open-output-string)])
+       (remove-toolchain! id))
+
+     (check-false (link-exists? tc-dir))
+     (check-false (directory-exists? real)
+                  "remove-toolchain! should remove the prefix target")
+     (check-false (directory-exists? addon))
+     (check-false (toolchain-exists? id)))))


### PR DESCRIPTION
Adds `rackup install --prefix <path>` (with `RACKUP_TOOLCHAIN_PREFIX`
fallback). The toolchain is materialized at `<prefix>/<id>/` on disk and
`~/.rackup/toolchains/<id>` becomes an absolute symlink to it, so all
existing path lookups resolve transparently through the link. The prefix
is recorded in `meta.rktd` and `rackup upgrade` replays it.

Useful when `~/.rackup` is on slow/networked storage and you want the
toolchain trees on a fast local disk like `/tmp`.

Cleanup is symlink-aware: `delete-toolchain-dir!` removes both the link
target and the link, and `toolchain-dir-occupied?` recognises dangling
symlinks so `--force` (and ghost-cleanup) can recover after the prefix
target is wiped (e.g., reboot clearing `/tmp`). `rackup doctor`
annotates each toolchain with its prefix or flags broken links.