### PR TITLE
Refactor static rackup-home path accessors

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -95,6 +95,7 @@ The `commit-state-change!` macro in `install.rkt` wraps a body in `with-state-lo
 ## State storage
 
 All rackup state lives under `RACKUP_HOME` (default `~/.rackup`). The layout is defined in `paths.rkt` as a collection of functions that compute paths from the home directory.
+Static paths under `RACKUP_HOME` are declared once in `paths.rkt` using a small mapping (`define-home-subpaths`), which generates simple zero-argument accessors like `rackup-bin-dir` and `rackup-state-dir`. Keep explicitly parameterized helpers (for example `rackup-toolchain-dir` and `rackup-addon-dir`) as regular functions so their call shape remains clear and unchanged.
 
 ### Index
 

--- a/libexec/rackup/paths.rkt
+++ b/libexec/rackup/paths.rkt
@@ -62,36 +62,28 @@
   (ensure-path-without-control-chars! home "RACKUP_HOME")
   home)
 
-(define (rackup-bin-dir)
-  (build-path (rackup-home) "bin"))
-(define (rackup-libexec-dir)
-  (build-path (rackup-home) "libexec"))
-(define (rackup-shims-dir)
-  (build-path (rackup-home) "shims"))
-(define (rackup-shell-dir)
-  (build-path (rackup-home) "shell"))
-(define (rackup-toolchains-dir)
-  (build-path (rackup-home) "toolchains"))
-(define (rackup-addons-dir)
-  (build-path (rackup-home) "addons"))
-(define (rackup-cache-dir)
-  (build-path (rackup-home) "cache"))
-(define (rackup-download-cache-dir)
-  (build-path (rackup-cache-dir) "downloads"))
-(define (rackup-state-dir)
-  (build-path (rackup-home) "state"))
-(define (rackup-runtime-dir)
-  (build-path (rackup-home) "runtime"))
-(define (rackup-runtime-addon-dir)
-  (build-path (rackup-runtime-dir) "addon"))
-(define (rackup-runtime-versions-dir)
-  (build-path (rackup-runtime-dir) "versions"))
-(define (rackup-runtime-current-link)
-  (build-path (rackup-runtime-dir) "current"))
-(define (rackup-runtime-lock-dir)
-  (build-path (rackup-runtime-dir) ".lock"))
-(define (rackup-state-lock-dir)
-  (build-path (rackup-state-dir) ".lock"))
+(define-syntax-rule (define-home-subpaths [name segment ...] ...)
+  (begin
+    (define (name)
+      (build-path (rackup-home) segment ...))
+    ...))
+
+(define-home-subpaths
+  [rackup-bin-dir "bin"]
+  [rackup-libexec-dir "libexec"]
+  [rackup-shims-dir "shims"]
+  [rackup-shell-dir "shell"]
+  [rackup-toolchains-dir "toolchains"]
+  [rackup-addons-dir "addons"]
+  [rackup-cache-dir "cache"]
+  [rackup-download-cache-dir "cache" "downloads"]
+  [rackup-state-dir "state"]
+  [rackup-runtime-dir "runtime"]
+  [rackup-runtime-addon-dir "runtime" "addon"]
+  [rackup-runtime-versions-dir "runtime" "versions"]
+  [rackup-runtime-current-link "runtime" "current"]
+  [rackup-runtime-lock-dir "runtime" ".lock"]
+  [rackup-state-lock-dir "state" ".lock"])
 
 (define (rackup-runtime-version-dir id)
   (build-path (rackup-runtime-versions-dir) id))


### PR DESCRIPTION
### Motivation
- Reduce repetitive boilerplate for zero-argument path accessors that derive from `rackup-home` by using a small declarative mapping. 
- Keep explicitly parameterized path helpers separate and preserve all public API names so callers are unaffected.

### Description
- Add a `define-home-subpaths` mapping macro in `libexec/rackup/paths.rkt` which generates simple zero-argument accessors from a list of name → path-segment entries. 
- Replace the previous repetitive `define` forms for static `RACKUP_HOME` subpaths with a single `define-home-subpaths` invocation that declares `rackup-bin-dir`, `rackup-libexec-dir`, `rackup-shims-dir`, etc. 
- Leave parameterized helpers such as `rackup-toolchain-dir`, `rackup-addon-dir`, and related functions intact and unchanged. 
- Add a short developer note to `docs/IMPLEMENTATION.md` explaining the new layout-definition pattern and the separation from parameterized helpers.

### Testing
- Attempted to `require` the modified module with `racket -l racket/base -e '(require "libexec/rackup/paths.rkt") (void)'` but the command failed in this environment because `racket` is not installed (`command not found`).
- No other automated test coverage was run in this environment due to the missing Racket runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6720fcac88328bc70bd1cc32fefdf)