### PR TITLE
Centralize rackup home-derived path construction

### DIFF
--- a/libexec/rackup-bootstrap.sh
+++ b/libexec/rackup-bootstrap.sh
@@ -52,8 +52,24 @@ rackup_runtime_cache_dir() {
   printf '%s\n' "$(rackup_home)/cache/downloads"
 }
 
+rackup_state_dir() {
+  printf '%s\n' "$(rackup_home)/state"
+}
+
+rackup_toolchains_dir() {
+  printf '%s\n' "$(rackup_home)/toolchains"
+}
+
+rackup_addons_dir() {
+  printf '%s\n' "$(rackup_home)/addons"
+}
+
+rackup_shims_dir() {
+  printf '%s\n' "$(rackup_home)/shims"
+}
+
 rackup_default_toolchain_file() {
-  printf '%s\n' "$(rackup_home)/state/default-toolchain"
+  printf '%s\n' "$(rackup_state_dir)/default-toolchain"
 }
 
 rackup_read_default_toolchain_shell() {
@@ -65,7 +81,7 @@ rackup_read_default_toolchain_shell() {
 
 rackup_toolchain_meta_file_shell() {
   toolchain_id="$1"
-  printf '%s\n' "$(rackup_home)/toolchains/$toolchain_id/meta.rktd"
+  printf '%s\n' "$(rackup_toolchains_dir)/$toolchain_id/meta.rktd"
 }
 
 rackup_rktd_string_field_shell() {

--- a/libexec/rackup/paths.rkt
+++ b/libexec/rackup/paths.rkt
@@ -19,6 +19,8 @@
          rackup-runtime-addon-dir
          rackup-runtime-versions-dir
          rackup-runtime-current-link
+         rackup-runtime-current-bin-dir
+         rackup-runtime-current-racket
          rackup-runtime-lock-dir
          rackup-state-lock-dir
          rackup-runtime-version-dir
@@ -27,14 +29,18 @@
          rackup-runtime-bin-link
          rackup-index-file
          rackup-config-file
+         rackup-legacy-config-file
+         rackup-legacy-shim-aliases-file
          rackup-default-file
          rackup-shim-dispatcher
+         rackup-shim-path
          rackup-bin-entry
          rackup-shell-script
          rackup-toolchain-dir
          rackup-toolchain-install-dir
          rackup-toolchain-meta-file
          rackup-toolchain-bin-link
+         rackup-toolchain-exe-path
          rackup-toolchain-env-file
          rackup-addon-dir
          ensure-rackup-layout!)
@@ -88,6 +94,10 @@
   (build-path (rackup-runtime-dir) "versions"))
 (define (rackup-runtime-current-link)
   (build-path (rackup-runtime-dir) "current"))
+(define (rackup-runtime-current-bin-dir)
+  (build-path (rackup-runtime-current-link) "bin"))
+(define (rackup-runtime-current-racket)
+  (build-path (rackup-runtime-current-bin-dir) "racket"))
 (define (rackup-runtime-lock-dir)
   (build-path (rackup-runtime-dir) ".lock"))
 (define (rackup-state-lock-dir)
@@ -106,11 +116,17 @@
   (build-path (rackup-state-dir) "index.rktd"))
 (define (rackup-config-file)
   (build-path (rackup-state-dir) "config"))
+(define (rackup-legacy-config-file)
+  (build-path (rackup-state-dir) "config.rktd"))
+(define (rackup-legacy-shim-aliases-file)
+  (build-path (rackup-state-dir) "shim-aliases"))
 (define (rackup-default-file)
   (build-path (rackup-state-dir) "default-toolchain"))
 
 (define (rackup-shim-dispatcher)
   (build-path (rackup-libexec-dir) "rackup-shim"))
+(define (rackup-shim-path name)
+  (build-path (rackup-shims-dir) name))
 (define (rackup-bin-entry)
   (build-path (rackup-bin-dir) "rackup"))
 (define (rackup-shell-script shell-name)
@@ -124,6 +140,8 @@
   (build-path (rackup-toolchain-dir id) "meta.rktd"))
 (define (rackup-toolchain-bin-link id)
   (build-path (rackup-toolchain-dir id) "bin"))
+(define (rackup-toolchain-exe-path id exe)
+  (build-path (rackup-toolchain-bin-link id) exe))
 (define (rackup-toolchain-env-file id)
   (build-path (rackup-toolchain-dir id) "env.sh"))
 (define (rackup-addon-dir id)

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -33,7 +33,7 @@
          (append (hidden-runtime-invocation-prefix racket-exe) args)))
 
 (define (hidden-runtime-racket-path)
-  (define p (build-path (rackup-runtime-current-link) "bin" "racket"))
+  (define p (rackup-runtime-current-racket))
   (and (executable-file? p) p))
 
 (define (hidden-runtime-present?)
@@ -255,8 +255,8 @@
                 'platform
                 (host-platform-token)))
         (define real-bin
-          (with-handlers ([exn:fail? (lambda (_) (build-path (rackup-runtime-current-link) "bin"))])
-            (resolve-path (build-path (rackup-runtime-current-link) "bin"))))
+          (with-handlers ([exn:fail? (lambda (_) (rackup-runtime-current-bin-dir))])
+            (resolve-path (rackup-runtime-current-bin-dir))))
         (write-runtime-meta! current-id
                              req
                              real-bin

--- a/libexec/rackup/shims.rkt
+++ b/libexec/rackup/shims.rkt
@@ -256,7 +256,7 @@ EOF
 
 (define (ensure-core-rackup-shim!)
   (ensure-rackup-layout!)
-  (define shim (build-path (rackup-shims-dir) "rackup"))
+  (define shim (rackup-shim-path "rackup"))
   (when (or (link-exists? shim) (file-exists? shim))
     (delete-file shim))
   (make-file-or-directory-link (rackup-bin-entry) shim)
@@ -282,7 +282,7 @@ EOF
   (define id (or toolchain-id (resolve-active-toolchain-id)))
   (unless id
     (rackup-error "no active/default toolchain configured"))
-  (define p (build-path (rackup-toolchain-bin-link id) exe))
+  (define p (rackup-toolchain-exe-path id exe))
   (if (file-exists? p)
       p
       (find-addon-bin-exe (rackup-addon-dir id) exe)))

--- a/libexec/rackup/state.rkt
+++ b/libexec/rackup/state.rkt
@@ -64,12 +64,12 @@
   (unless (file-exists? (rackup-index-file))
     (save-index! (empty-index)))
   ;; Migrate old config.rktd to plain text config if needed
-  (define old-config (build-path (rackup-state-dir) "config.rktd"))
+  (define old-config (rackup-legacy-config-file))
   (when (and (file-exists? old-config) (not (file-exists? (rackup-config-file))))
     (write-string-file (rackup-config-file) "")
     (delete-file old-config))
   ;; Migrate old shim-aliases marker to config flag
-  (define old-aliases (build-path (rackup-state-dir) "shim-aliases"))
+  (define old-aliases (rackup-legacy-shim-aliases-file))
   (when (file-exists? old-aliases)
     (set-config-flag! "short-aliases")
     (delete-file old-aliases))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -718,8 +718,8 @@ if [ "$INSTALLED_PREBUILT" -eq 1 ]; then
   . "$PREFIX/libexec/rackup-bootstrap.sh"
   # No hidden runtime needed — the prebuilt binary embeds its own Racket.
   # Remove any stale hidden runtime from a prior source install.
-  if [ -d "$PREFIX/runtime" ]; then
-    rm -rf "$PREFIX/runtime"
+  if [ -d "$(rackup_runtime_dir)" ]; then
+    rm -rf "$(rackup_runtime_dir)"
   fi
   # Also remove stale source files from a prior source install.
   if [ -f "$PREFIX/libexec/rackup-core.rkt" ]; then

--- a/test/all.rkt
+++ b/test/all.rkt
@@ -3,6 +3,7 @@
 (require rackunit/text-ui
          "copy-filtered-tree.rkt"
          "install-prefix.rkt"
+         "paths.rkt"
          "rebuild.rkt"
          "rktd-io.rkt"
          "shell-completion.rkt"

--- a/test/paths.rkt
+++ b/test/paths.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+(require rackunit
+         racket/path
+         "../libexec/rackup/paths.rkt")
+
+(define (with-temp-rackup-home proc)
+  (define tmp (make-temporary-file "rackup-paths-test~a" 'directory))
+  (define old-home (getenv "RACKUP_HOME"))
+  (dynamic-wind (lambda () (putenv "RACKUP_HOME" (path->string tmp)))
+                (lambda () (proc tmp))
+                (lambda ()
+                  (if old-home
+                      (putenv "RACKUP_HOME" old-home)
+                      (putenv "RACKUP_HOME" ""))
+                  (delete-directory/files tmp #:must-exist? #f))))
+
+(module+ test
+  (with-temp-rackup-home
+   (lambda (tmp)
+     (check-equal? (rackup-state-dir) (build-path tmp "state"))
+     (check-equal? (rackup-toolchains-dir) (build-path tmp "toolchains"))
+     (check-equal? (rackup-addons-dir) (build-path tmp "addons"))
+     (check-equal? (rackup-shims-dir) (build-path tmp "shims"))
+     (check-equal? (rackup-runtime-dir) (build-path tmp "runtime"))
+     (check-equal? (rackup-runtime-current-bin-dir)
+                   (build-path tmp "runtime" "current" "bin"))
+     (check-equal? (rackup-runtime-current-racket)
+                   (build-path tmp "runtime" "current" "bin" "racket"))
+     (check-equal? (rackup-legacy-config-file) (build-path tmp "state" "config.rktd"))
+     (check-equal? (rackup-legacy-shim-aliases-file) (build-path tmp "state" "shim-aliases"))
+     (check-equal? (rackup-shim-path "racket") (build-path tmp "shims" "racket"))
+     (check-equal? (rackup-toolchain-exe-path "stable" "racket")
+                   (build-path tmp "toolchains" "stable" "bin" "racket")))))
+


### PR DESCRIPTION
### Motivation
- Reduce duplicated ad-hoc `build-path` uses that encode `RACKUP_HOME` substructure and avoid drift between Racket code and shell entrypoints. 
- Make derived locations (runtime current bin/racket, legacy state migration files, shim/toolchain exe paths) single-sourced so callers can evolve layout safely.

### Description
- Added new helpers to `libexec/rackup/paths.rkt`: `rackup-runtime-current-bin-dir`, `rackup-runtime-current-racket`, `rackup-legacy-config-file`, `rackup-legacy-shim-aliases-file`, `rackup-shim-path`, and `rackup-toolchain-exe-path`, and exported them for reuse. 
- Replaced in-code path composition with the new helpers across modules (`libexec/rackup/runtime.rkt`, `libexec/rackup/state.rkt`, `libexec/rackup/shims.rkt`) to centralize semantics. 
- Extended the shell bootstrap helper `libexec/rackup-bootstrap.sh` with corresponding shell functions (`rackup_state_dir`, `rackup_toolchains_dir`, `rackup_addons_dir`, `rackup_shims_dir`, etc.) and adjusted consumers; updated `scripts/install.sh` to call the runtime helper when removing stale runtime directories. 
- Added `test/paths.rkt` to validate helper outputs under a custom `RACKUP_HOME` and wired it into `test/all.rkt` so the new helpers are exercised by the test suite. 

### Testing
- Added unit tests in `test/paths.rkt` that assert each new helper returns the expected `build-path` under a temporary `RACKUP_HOME`. 
- Ran the test command `raco test test/paths.rkt test/state-shims.rkt test/install-prefix.rkt`, which failed to run in this environment because `raco` was not available (`/bin/bash: raco: command not found`). 
- No other automated tests were executed in this runner; the changes are localized to path construction and to the shell bootstrap helpers used by entrypoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f670df0a4c832893bc0d10b8e26176)