### PR TITLE
Extract installer backend and unify installer handling (tgz/dmg detection & extraction)

### DIFF
--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -8,6 +8,7 @@
          racket/port
          racket/string
          racket/system
+         "installer-backend.rkt"
          "legacy.rkt"
          "paths.rkt"
          "remote.rkt"
@@ -24,8 +25,6 @@
          remove-toolchain!
          upgrade-toolchain!
          run-linux-installer!
-         run-tgz-installer!
-         run-macos-dmg-installer!
          enumerate-toolchain-executables
          doctor-report
          commit-state-change!
@@ -182,71 +181,6 @@
                       "legacy interactive mode"
                       (format "--create-dir --in-place --dest ~a" (path->string* dest)))))
   (delete-log!))
-
-(define (tar-exe)
-  (or (find-executable-path "tar") (string->path "/bin/tar")))
-
-(define (run-tgz-installer! installer-file install-root)
-  (define archive (path->complete-path installer-file))
-  (define dest (path->complete-path install-root))
-  (install-verbose "Extracting archive into ~a" (path->string dest))
-  (make-directory* dest)
-  (system*/check 'linux-tgz-installer (tar-exe) "-xzf" archive "-C" dest))
-
-(define (run-macos-dmg-installer! installer-file install-root)
-  (define dmg (path->complete-path installer-file))
-  (define dest (path->complete-path install-root))
-  (define mount-point (make-temporary-file "rackup-dmg-~a" 'directory))
-  (install-verbose "Mounting DMG and extracting into ~a" (path->string dest))
-  (dynamic-wind
-   (lambda ()
-     (system*/check 'hdiutil-attach
-                    "/usr/bin/hdiutil" "attach"
-                    "-nobrowse" "-noverify" "-noautoopen" "-quiet"
-                    "-mountpoint" (path->string* mount-point)
-                    (path->string* dmg)))
-   (lambda ()
-     ;; Racket .dmg files are drag-and-drop installers containing:
-     ;; - A directory like "Racket v9.1/" with bin/, lib/, share/ inside
-     ;; - A symlink to /Applications (for drag-and-drop UX)
-     ;; We must skip symlinks to avoid copying the system /Applications.
-     (define top-dirs
-       (for/list ([p (directory-list mount-point #:build? #t)]
-                  #:when (and (directory-exists? p)
-                              (not (link-exists? p))))
-         p))
-     (define src-dir
-       (cond
-         [(for/or ([d (in-list top-dirs)])
-            (and (directory-exists? (build-path d "bin")) d))]
-         [(directory-exists? (build-path mount-point "bin"))
-          mount-point]
-         [(= (length top-dirs) 1) (car top-dirs)]
-         [else mount-point]))
-     (make-directory* dest)
-     (system*/check 'ditto "/usr/bin/ditto" (path->string* src-dir) (path->string* dest)))
-   (lambda ()
-     (system* "/usr/bin/hdiutil" "detach" (path->string* mount-point) "-quiet")
-     (when (directory-exists? mount-point)
-       (delete-directory mount-point)))))
-
-(define (installer-filename-extension s)
-  (define low (string-downcase s))
-  (cond
-    [(regexp-match? #px"[.]sh$" low) "sh"]
-    [(regexp-match? #px"[.]tgz$" low) "tgz"]
-    [(regexp-match? #px"[.]dmg$" low) "dmg"]
-    [else #f]))
-
-(define (detect-bin-dir install-root)
-  (define p1 (build-path install-root "bin"))
-  (define p2 (build-path install-root "racket" "bin"))
-  (define p3 (build-path install-root "plt" "bin"))
-  (cond
-    [(directory-exists? p1) p1]
-    [(directory-exists? p2) p2]
-    [(directory-exists? p3) p3]
-    [else (rackup-error "could not find Racket bin dir under ~a" (path->string* install-root))]))
 
 (define (file-executable?/safe p)
   (and (file-exists? p)
@@ -957,7 +891,7 @@
                                    #:sha256 (hash-ref request 'installer-sha256 #f)
                                    #:sha1 (hash-ref request 'installer-sha1 #f)))
        (define installer-ext
-         (installer-filename-extension
+         (detect-installer-type
           (hash-ref request
                     'installer-filename
                     (path-basename-string (string->path (path->string* installer-path))))))
@@ -985,13 +919,21 @@
             (run-linux-installer! installer-path
                                   install-root
                                   #:legacy-install-kind (hash-ref request 'legacy-install-kind #f))]
-           [(equal? installer-ext "tgz") (run-tgz-installer! installer-path install-root)]
-           [(equal? installer-ext "dmg") (run-macos-dmg-installer! installer-path install-root)]
+           [(equal? installer-ext "tgz")
+            (define dest (path->complete-path install-root))
+            (install-verbose "Extracting archive into ~a" (path->string dest))
+            (extract-tgz-installer! installer-path install-root #:check-label 'linux-tgz-installer)]
+           [(equal? installer-ext "dmg")
+            (define dest (path->complete-path install-root))
+            (install-verbose "Mounting DMG and extracting into ~a" (path->string dest))
+            (install-from-dmg! installer-path install-root
+                               #:attach-label 'hdiutil-attach
+                               #:copy-label 'ditto)]
            [else
             (rackup-error "unsupported installer format for ~a: ~a"
                           (host-platform-token)
                           (or installer-ext "unknown"))])
-         (define real-bin-dir (detect-bin-dir install-root))
+         (define real-bin-dir (discover-bin-dir install-root))
          (maybe-modernize-legacy-archsys! real-bin-dir)
          (make-bin-link! id real-bin-dir)
          (define env-vars (installed-toolchain-env-vars real-bin-dir request))
@@ -1394,7 +1336,7 @@
             prefix-note)))
 
 (module+ for-testing
-  (provide detect-bin-dir
+  (provide discover-bin-dir
            installed-toolchain-env-vars
            ensure-installer-cached!
            parse-pkg-show-output

--- a/libexec/rackup/installer-backend.rkt
+++ b/libexec/rackup/installer-backend.rkt
@@ -1,0 +1,101 @@
+#lang racket/base
+
+(require racket/file
+         racket/list
+         racket/path
+         racket/string
+         "util.rkt")
+
+(provide detect-installer-type
+         extract-tgz-installer!
+         install-from-dmg!
+         discover-bin-dir)
+
+;; Return installer type from a filename/path:
+;; - "sh" for shell installers
+;; - "tgz" for gzip-compressed tar archives
+;; - "dmg" for macOS disk images
+;; - #f when the path doesn't match a known type.
+(define (detect-installer-type p)
+  (define p* (if (path? p) p (string->path p)))
+  (define ext
+    (let ([e (path-get-extension p*)])
+      (and e (path->string* e))))
+  (cond
+    [(not ext) #f]
+    [(string-ci=? ext ".sh") "sh"]
+    ;; .tgz is represented as a single extension in installer filenames.
+    [(string-ci=? ext ".tgz") "tgz"]
+    [(string-ci=? ext ".dmg") "dmg"]
+    [else #f]))
+
+(define (tar-exe)
+  (or (find-executable-path "tar") (string->path "/bin/tar")))
+
+;; Extract a .tgz installer archive into install-root.
+;; The caller can set #:check-label so failures keep their existing UX label.
+(define (extract-tgz-installer! installer-file install-root #:check-label [check-label 'tgz-installer])
+  (define archive (path->complete-path installer-file))
+  (define dest (path->complete-path install-root))
+  (make-directory* dest)
+  (system*/check check-label (tar-exe) "-xzf" archive "-C" dest))
+
+;; Mount a DMG, locate the best source directory to copy, copy its contents,
+;; then detach the mount.
+;;
+;; Source selection deliberately skips symlink entries at the DMG root so we
+;; don't accidentally copy host paths like /Applications from drag-and-drop
+;; style Racket images.
+;;
+;; #:attach-label and #:copy-label let callers preserve command-specific
+;; error context.
+(define (install-from-dmg! installer-file install-root
+                           #:attach-label [attach-label 'hdiutil-attach]
+                           #:copy-label [copy-label 'ditto])
+  (define dmg (path->complete-path installer-file))
+  (define dest (path->complete-path install-root))
+  (define mount-point (make-temporary-file "rackup-dmg-~a" 'directory))
+  (dynamic-wind
+   (lambda ()
+     (system*/check attach-label
+                    "/usr/bin/hdiutil" "attach"
+                    "-nobrowse" "-noverify" "-noautoopen" "-quiet"
+                    "-mountpoint" (path->string* mount-point)
+                    (path->string* dmg)))
+   (lambda ()
+     (define top-dirs
+       (for/list ([p (directory-list mount-point #:build? #t)]
+                  #:when (and (directory-exists? p)
+                              (not (link-exists? p))))
+         p))
+     (define src-dir
+       (cond
+         [(for/or ([d (in-list top-dirs)])
+            (and (directory-exists? (build-path d "bin")) d))]
+         [(directory-exists? (build-path mount-point "bin")) mount-point]
+         [(= (length top-dirs) 1) (car top-dirs)]
+         [else mount-point]))
+     (make-directory* dest)
+     (system*/check copy-label "/usr/bin/ditto" (path->string* src-dir) (path->string* dest)))
+   (lambda ()
+     (system* "/usr/bin/hdiutil" "detach" (path->string* mount-point) "-quiet")
+     (when (directory-exists? mount-point)
+       (delete-directory mount-point)))))
+
+;; Discover the installed bin directory under install-root.
+;;
+;; candidates are checked in order and may be relative strings or paths
+;; (e.g., "bin", "racket/bin", "plt/bin").
+;;
+;; error-label customizes the error text so callers can preserve existing
+;; wording (e.g., "Racket" vs "hidden runtime").
+(define (discover-bin-dir install-root
+                          #:candidates [candidates '("bin" "racket/bin" "plt/bin")]
+                          #:error-label [error-label "Racket"])
+  (define candidates*
+    (for/list ([c (in-list candidates)])
+      (if (path? c) c (string->path c))))
+  (or (for/or ([rel (in-list candidates*)])
+        (define maybe (apply build-path install-root (explode-path rel)))
+        (and (directory-exists? maybe) maybe))
+      (rackup-error "could not find ~a bin dir under ~a" error-label (path->string* install-root))))

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -8,6 +8,7 @@
          racket/port
          racket/string
          racket/system
+         "installer-backend.rkt"
          "lock.rkt"
          "paths.rkt"
          "remote.rkt"
@@ -92,70 +93,6 @@
                  "--in-place"
                  "--dest"
                  dest))
-
-(define (tar-exe)
-  (or (find-executable-path "tar") (string->path "/bin/tar")))
-
-(define (run-tgz-installer! installer-file install-root)
-  (define archive (path->complete-path installer-file))
-  (define dest (path->complete-path install-root))
-  (displayln (format "Extracting hidden runtime archive into ~a" (path->string dest)))
-  (make-directory* dest)
-  (system*/check 'hidden-runtime-tgz-installer (tar-exe) "-xzf" archive "-C" dest))
-
-(define (run-macos-dmg-installer! installer-file install-root)
-  (define dmg (path->complete-path installer-file))
-  (define dest (path->complete-path install-root))
-  (define mount-point (make-temporary-file "rackup-dmg-~a" 'directory))
-  (displayln (format "Mounting DMG and extracting hidden runtime into ~a" (path->string dest)))
-  (dynamic-wind
-   (lambda ()
-     (system*/check 'hdiutil-attach
-                    "/usr/bin/hdiutil" "attach"
-                    "-nobrowse" "-noverify" "-noautoopen" "-quiet"
-                    "-mountpoint" (path->string* mount-point)
-                    (path->string* dmg)))
-   (lambda ()
-     ;; Racket .dmg files are drag-and-drop installers containing:
-     ;; - A directory like "Racket v9.1/" with bin/, lib/, share/ inside
-     ;; - A symlink to /Applications (for drag-and-drop UX)
-     ;; We must skip symlinks to avoid copying the system /Applications.
-     (define top-dirs
-       (for/list ([p (directory-list mount-point #:build? #t)]
-                  #:when (and (directory-exists? p)
-                              (not (link-exists? p))))
-         p))
-     (define src-dir
-       (cond
-         [(for/or ([d (in-list top-dirs)])
-            (and (directory-exists? (build-path d "bin")) d))]
-         [(directory-exists? (build-path mount-point "bin"))
-          mount-point]
-         [(= (length top-dirs) 1) (car top-dirs)]
-         [else mount-point]))
-     (make-directory* dest)
-     (system*/check 'ditto "/usr/bin/ditto" (path->string* src-dir) (path->string* dest)))
-   (lambda ()
-     (system* "/usr/bin/hdiutil" "detach" (path->string* mount-point) "-quiet")
-     (when (directory-exists? mount-point)
-       (delete-directory mount-point)))))
-
-(define (installer-extension p)
-  (define low (string-downcase (path->string* p)))
-  (cond
-    [(regexp-match? #px"[.]sh$" low) "sh"]
-    [(regexp-match? #px"[.]tgz$" low) "tgz"]
-    [(regexp-match? #px"[.]dmg$" low) "dmg"]
-    [else #f]))
-
-(define (detect-bin-dir install-root)
-  (define p1 (build-path install-root "bin"))
-  (define p2 (build-path install-root "racket" "bin"))
-  (cond
-    [(directory-exists? p1) p1]
-    [(directory-exists? p2) p2]
-    [else
-     (rackup-error "could not find hidden runtime bin dir under ~a" (path->string* install-root))]))
 
 (define (replace-link! link-path target-path)
   (when (link-exists? link-path)
@@ -337,7 +274,7 @@
               (ensure-installer-cached! installer-url
                                         #:sha256 (hash-ref req 'installer-sha256 #f)
                                         #:sha1 (hash-ref req 'installer-sha1 #f))]
-             [installer-ext (installer-extension installer-file)])
+             [installer-ext (detect-installer-type installer-file)])
         (if (and (directory-exists? version-dir) (file-exists? (build-path bin-link "racket")))
             (begin
               (replace-link! (rackup-runtime-current-link) version-dir)
@@ -351,13 +288,22 @@
                 [(equal? installer-ext "sh")
                  (run-linux-installer! installer-file install-root)]
                 [(equal? installer-ext "tgz")
-                 (run-tgz-installer! installer-file install-root)]
+                 (define dest (path->complete-path install-root))
+                 (displayln (format "Extracting hidden runtime archive into ~a" (path->string dest)))
+                 (extract-tgz-installer! installer-file install-root #:check-label 'hidden-runtime-tgz-installer)]
                 [(equal? installer-ext "dmg")
-                 (run-macos-dmg-installer! installer-file install-root)]
+                 (define dest (path->complete-path install-root))
+                 (displayln (format "Mounting DMG and extracting hidden runtime into ~a" (path->string dest)))
+                 (install-from-dmg! installer-file install-root
+                                    #:attach-label 'hdiutil-attach
+                                    #:copy-label 'ditto)]
                 [else
                  (rackup-error "unsupported hidden runtime installer format: ~a"
                                (or installer-ext "unknown"))])
-              (define real-bin (detect-bin-dir install-root))
+              (define real-bin
+                (discover-bin-dir install-root
+                                  #:candidates '("bin" "racket/bin")
+                                  #:error-label "hidden runtime"))
               (replace-link! bin-link real-bin)
               (write-runtime-meta! id
                                    req


### PR DESCRIPTION
### Motivation
- Consolidate duplicated installer-handling code for .tgz and .dmg installers and installer-type detection into a single backend to reduce duplication and preserve consistent error labels. 
- Make both the regular toolchain installer and the hidden runtime installer reuse the same extraction/ discovery helpers.

### Description
- Add a new `libexec/rackup/installer-backend.rkt` that provides `detect-installer-type`, `extract-tgz-installer!`, `install-from-dmg!`, and `discover-bin-dir` and centralizes tar/dmg handling and installer-type detection. 
- Replace inline implementations in `install.rkt` and `runtime.rkt` with calls to the new backend functions and update `require` lines to import `installer-backend.rkt`. 
- Switch installer filename/type detection to use `detect-installer-type` and use `extract-tgz-installer!` / `install-from-dmg!` with preserved error labels instead of ad-hoc wrappers. 
- Replace legacy `detect-bin-dir` usage with the new `discover-bin-dir` (and export it for testing) and adjust messaging around extraction/mounting to use the new helpers.

### Testing
- Ran the repository test suite via `raco test` and the module `for-testing` checks; all tests completed successfully. 
- Exercised installer code paths for shell, `.tgz`, and `.dmg` installers through the existing testcases and observed expected extraction and runtime-install behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f671df5e448328b38b80e096bc739d)