### PR TITLE
Use recspecs shell helpers and add command-output/check for robust command execution

### DIFF
--- a/test/docker-e2e.rkt
+++ b/test/docker-e2e.rkt
@@ -3,9 +3,10 @@
 ;; Shared Docker E2E helpers used by the Racket-ported orchestration scripts.
 
 (require racket/format
+         recspecs
+         recspecs/shell
          racket/list
          racket/path
-         racket/port
          racket/runtime-path
          racket/string
          racket/system)
@@ -14,6 +15,7 @@
          docker-build-e2e-image
          docker-run-container
          run/check
+         command-output/check
          uid-gid
          sanitize-tag
          csv-join)
@@ -24,21 +26,48 @@
 ;; Run a command, raising an error on failure.
 (define (run/check prog . args)
   (define cmd (cons prog args))
-  (unless (apply system*
-                 (if (path? prog)
-                     (path->string prog)
-                     prog)
-                 (map (lambda (a)
-                        (if (path? a)
-                            (path->string a)
-                            a))
-                      args))
-    (error 'run/check "command failed: ~a" (string-join (map ~a cmd) " "))))
+  (with-handlers ([exn:fail?
+                   (lambda (_e)
+                     (error 'run/check "command failed: ~a" (string-join (map ~a cmd) " ")))])
+    (expect/shell (map (lambda (a)
+                         (if (path? a)
+                             (path->string a)
+                             a))
+                       cmd)
+                  #:status 0
+                  #:match 'regexp
+                  #px"(?s:.*)")))
+
+;; Run a command and return trimmed stdout, raising an error on failure.
+(define (command-output/check prog . args)
+  (define cmd (cons prog args))
+  (define cmd-text (string-join (map ~a cmd) " "))
+  (define ok? #t)
+  (define-values (out err)
+    (capture-output/split
+     (lambda ()
+       (set! ok?
+             (apply system*
+                    (if (path? prog)
+                        (path->string prog)
+                        prog)
+                    (map (lambda (a)
+                           (if (path? a)
+                               (path->string a)
+                               a))
+                         args))))))
+  (unless ok?
+    (error 'command-output/check
+           "command failed: ~a\nstderr: ~a"
+           cmd-text
+           (string-trim err)))
+  (string-trim out))
 
 ;; Current uid:gid string for --user.
 (define uid-gid
-  (string-trim (with-output-to-string (lambda ()
-                                        (system "printf '%s:%s' \"$(id -u)\" \"$(id -g)\"")))))
+  (format "~a:~a"
+          (command-output/check "id" "-u")
+          (command-output/check "id" "-g")))
 
 ;; Sanitize a string for use as a Docker tag component.
 (define (sanitize-tag s)

--- a/test/docker-run-transcript-matrix.rkt
+++ b/test/docker-run-transcript-matrix.rkt
@@ -3,9 +3,7 @@
 (require racket/cmdline
          racket/file
          racket/format
-         racket/port
          racket/string
-         racket/system
          "docker-e2e.rkt")
 
 (define host-racket "absent")
@@ -36,7 +34,7 @@
 
 (unless transcript-path
   (define stamp
-    (string-trim (with-output-to-string (lambda () (system "date -u '+%Y%m%dT%H%M%SZ'")))))
+    (command-output/check "date" "-u" "+%Y%m%dT%H%M%SZ"))
   (set! transcript-path
         (path->string (build-path root-dir
                                   "artifacts"
@@ -50,15 +48,13 @@
 
 ;; Write transcript header and run container, teeing to file.
 (define commit
-  (string-trim (with-output-to-string
-                (lambda () (system (format "git -C ~a rev-parse HEAD" (path->string root-dir)))))))
+  (command-output/check "git" "-C" (path->string root-dir) "rev-parse" "HEAD"))
 
 (define header
   (string-join (list "rackup expanded docker transcript"
                      (format "commit: ~a" commit)
                      (format "generated: ~a"
-                             (string-trim (with-output-to-string
-                                           (lambda () (system "date -u '+%Y-%m-%dT%H:%M:%SZ'")))))
+                             (command-output/check "date" "-u" "+%Y-%m-%dT%H:%M:%SZ"))
                      (format "image: ~a" image-tag)
                      (format "host_racket: ~a" host-racket)
                      (format "trace: ~a" trace)


### PR DESCRIPTION
### Motivation
- Replace fragile `system` + output-capture patterns with higher-level shell helpers to improve error handling and output trimming.
- Provide a reusable helper to capture and return command stdout while surfacing stderr on failure.
- Make UID/GID, `git` and `date` invocations deterministic and easier to test by centralizing command execution.

### Description
- Add `recspecs` and `recspecs/shell` to the test helper `require`s and export a new `command-output/check` helper. 
- Implement `command-output/check` to run a command, capture stdout/stderr via `capture-output/split`, trim stdout, and raise an error with stderr on failure. 
- Replace ad-hoc `system` calls and `with-output-to-string` captures in `run/check`, `uid-gid`, and places that invoked `date` and `git rev-parse` with calls to `expect/shell` or `command-output/check` and improved error handling. 
- Update `run/check` to use `expect/shell` with a status match and wrap failures in a descriptive error message.

### Testing
- Ran the modified test scripts `test/docker-e2e.rkt` and `test/docker-run-transcript-matrix.rkt` as part of the test suite; they completed successfully. 
- Existing automated checks that exercise `uid-gid`, `date`, and `git` command paths passed after the change. 
- No new failing automated tests were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67200afdc8328b58d6caa405df94e)