### PR TITLE
Racket-first Docker E2E orchestration, transcript helpers, and docs

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -280,3 +280,12 @@ The install site at `samth.github.io/rackup` is built and deployed by two workfl
 **Deployment.** `pages.yml` is triggered by pushes to main. It rebuilds the site, runs a `bootstrap-curl` smoke test (Docker container running `curl | sh` against the built site to verify the full install path works), and only then packages and deploys the Pages artifact.
 
 CI verifies that every user-facing command from `rackup help` appears on the generated webpage, and that the source tarball contains no compiled artifacts.
+
+## E2E architecture
+
+Rackup’s Docker E2E boundary is **Racket-first orchestration** with shell scripts limited to in-container scenario steps.
+
+- **Racket orchestration (`test/docker-*.rkt`) owns**: timestamps, commit metadata capture, transcript headers, Docker `run` argument construction, and standardized environment-variable assembly passed into the container.
+- **Container shell scripts (`test/e2e-*-container.sh`) own**: scenario execution only (install/switch/run/remove flows and assertions inside the container filesystem).
+- **Boundary rule**: container scripts should not duplicate orchestration plumbing (metadata emission, host git/date calls, or generic Docker env assembly) when those can be provided by the Racket caller.
+

--- a/test/docker-e2e.rkt
+++ b/test/docker-e2e.rkt
@@ -2,17 +2,24 @@
 
 ;; Shared Docker E2E helpers used by the Racket-ported orchestration scripts.
 
-(require racket/format
+(require racket/date
+         racket/format
          racket/list
          racket/path
          racket/port
          racket/runtime-path
          racket/string
-         racket/system)
+         racket/system
+         remote-shell/ssh)
 
 (provide root-dir
          docker-build-e2e-image
          docker-run-container
+         current-utc-stamp
+         git-head-commit
+         transcript-header
+         standard-container-env
+         run/container->transcript
          run/check
          uid-gid
          sanitize-tag
@@ -20,6 +27,104 @@
 
 (define-runtime-path here ".")
 (define root-dir (simplify-path (build-path here "..")))
+
+(define localhost-remote (remote #:host "localhost"))
+
+(define (sh-quote s)
+  (string-append "'" (regexp-replace* #rx"'" s "'\\''") "'"))
+
+(define (run/remote-shell-check cmd)
+  (unless (ssh localhost-remote #:mode 'result cmd)
+    (error 'run/remote-shell-check "command failed: ~a" cmd)))
+
+(define (current-utc-stamp #:for-filename? [for-filename? #f])
+  (parameterize ([date-display-format 'iso-8601])
+    (define base (date->string (seconds->date (current-seconds) #t) #t))
+    (if for-filename?
+        (string-replace (string-replace base ":" "") "-" "")
+        base)))
+
+(define (git-head-commit)
+  (string-trim
+   (with-output-to-string
+     (lambda ()
+       (run/remote-shell-check
+        (format "git -C ~a rev-parse HEAD" (sh-quote (path->string root-dir))))))))
+
+(define (transcript-header #:image image-tag
+                           #:host-racket host-racket
+                           #:trace trace)
+  (string-join (list "rackup expanded docker transcript"
+                     (format "commit: ~a" (git-head-commit))
+                     (format "generated: ~a" (current-utc-stamp))
+                     (format "image: ~a" image-tag)
+                     (format "host_racket: ~a" host-racket)
+                     (format "trace: ~a" trace)
+                     "")
+               "\n"))
+
+(define (standard-container-env #:home home
+                                #:workdir [workdir "/work"]
+                                #:trace [trace #f]
+                                #:extra [extra '()])
+  (append (list (cons "HOME" home)
+                (cons "WORKDIR" workdir)
+                (cons "TMPDIR" "/tmp")
+                (cons "PATH" "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"))
+          (if trace
+              (list (cons "RACKUP_TRANSCRIPT_TRACE" trace))
+              '())
+          extra))
+
+(define (docker-run-argv #:image image-tag
+                         #:command command-args
+                         #:platform [platform #f]
+                         #:user [user uid-gid]
+                         #:home [home "/tmp/rackup-e2e-home"]
+                         #:volumes [volumes '()]
+                         #:env-vars [env-vars '()]
+                         #:extra-args [extra-args '()]
+                         #:workdir [workdir "/work"])
+  (append (list "docker" "run" "--rm")
+          (if platform (list "--platform" platform) '())
+          (list "--user" user)
+          (append-map (lambda (v) (list "-v" v)) volumes)
+          (append-map (lambda (e) (list "-e" (format "~a=~a" (car e) (cdr e)))) env-vars)
+          (list "-e" (format "HOME=~a" home))
+          (list "-w" workdir)
+          extra-args
+          (list image-tag)
+          command-args))
+
+(define (run/container->transcript #:image image-tag
+                                   #:command command-args
+                                   #:transcript-path transcript-path
+                                   #:header header
+                                   #:platform [platform #f]
+                                   #:user [user uid-gid]
+                                   #:home [home "/tmp/rackup-e2e-home"]
+                                   #:volumes [volumes '()]
+                                   #:env-vars [env-vars '()]
+                                   #:extra-args [extra-args '()]
+                                   #:workdir [workdir "/work"])
+  (call-with-output-file transcript-path
+    (lambda (out)
+      (display header out))
+    #:exists 'truncate/replace)
+  (define docker-cmd
+    (docker-run-argv #:image image-tag
+                     #:command command-args
+                     #:platform platform
+                     #:user user
+                     #:home home
+                     #:volumes volumes
+                     #:env-vars env-vars
+                     #:extra-args extra-args
+                     #:workdir workdir))
+  (run/remote-shell-check
+   (format "~a 2>&1 | tee -a ~a"
+           (string-join (map sh-quote docker-cmd) " ")
+           (sh-quote (path->string transcript-path)))))
 
 ;; Run a command, raising an error on failure.
 (define (run/check prog . args)
@@ -89,8 +194,8 @@
           image-tag
           base-image
           (or platform "native"))
-  (unless (apply system* full-cmd)
-    (error 'docker-build-e2e-image "docker build failed"))
+  (run/remote-shell-check
+   (string-join (map sh-quote full-cmd) " "))
   image-tag)
 
 ;; Run a container with standard options.
@@ -107,16 +212,13 @@
                               #:extra-args [extra-args '()]
                               #:workdir [workdir "/work"])
   (define cmd
-    (append (list "docker" "run" "--rm")
-            (if platform
-                (list "--platform" platform)
-                '())
-            (list "--user" user)
-            (append-map (lambda (v) (list "-v" v)) volumes)
-            (append-map (lambda (e) (list "-e" (format "~a=~a" (car e) (cdr e)))) env-vars)
-            (list "-e" (format "HOME=~a" home))
-            (list "-w" workdir)
-            extra-args
-            (list image-tag)
-            command-args))
-  (apply system* cmd))
+    (docker-run-argv #:image image-tag
+                     #:command command-args
+                     #:platform platform
+                     #:user user
+                     #:home home
+                     #:volumes volumes
+                     #:env-vars env-vars
+                     #:extra-args extra-args
+                     #:workdir workdir))
+  (ssh localhost-remote #:mode 'result (string-join (map sh-quote cmd) " ")) )

--- a/test/docker-run-transcript-matrix.rkt
+++ b/test/docker-run-transcript-matrix.rkt
@@ -3,9 +3,6 @@
 (require racket/cmdline
          racket/file
          racket/format
-         racket/port
-         racket/string
-         racket/system
          "docker-e2e.rkt")
 
 (define host-racket "absent")
@@ -35,8 +32,7 @@
   (set! image-tag (format "rackup-e2e:~a" host-racket)))
 
 (unless transcript-path
-  (define stamp
-    (string-trim (with-output-to-string (lambda () (system "date -u '+%Y%m%dT%H%M%SZ'")))))
+  (define stamp (current-utc-stamp #:for-filename? #t))
   (set! transcript-path
         (path->string (build-path root-dir
                                   "artifacts"
@@ -48,48 +44,16 @@
 (when build?
   (docker-build-e2e-image #:image-tag image-tag #:host-racket host-racket))
 
-;; Write transcript header and run container, teeing to file.
-(define commit
-  (string-trim (with-output-to-string
-                (lambda () (system (format "git -C ~a rev-parse HEAD" (path->string root-dir)))))))
-
 (define header
-  (string-join (list "rackup expanded docker transcript"
-                     (format "commit: ~a" commit)
-                     (format "generated: ~a"
-                             (string-trim (with-output-to-string
-                                           (lambda () (system "date -u '+%Y-%m-%dT%H:%M:%SZ'")))))
-                     (format "image: ~a" image-tag)
-                     (format "host_racket: ~a" host-racket)
-                     (format "trace: ~a" trace)
-                     "")
-               "\n"))
+  (transcript-header #:image image-tag #:host-racket host-racket #:trace trace))
 
-;; Use shell pipeline to tee output to the transcript file,
-;; matching the original: { header; docker run ... } 2>&1 | tee PATH
-(define shell-cmd
-  (format "{ printf '~a\\n' ; ~a ; } 2>&1 | tee ~a"
-          (regexp-replace* #rx"'" header "'\\\\''")
-          (string-join (list "docker"
-                             "run"
-                             "--rm"
-                             "--user"
-                             (format "'~a'" uid-gid)
-                             "-e"
-                             "HOME=/tmp/rackup-transcript-home"
-                             "-e"
-                             (format "RACKUP_TRANSCRIPT_TRACE=~a" trace)
-                             "-v"
-                             (format "'~a:/work'" (path->string root-dir))
-                             "-w"
-                             "/work"
-                             image-tag
-                             "bash"
-                             "/work/test/e2e-transcript-matrix-container.sh")
-                       " ")
-          transcript-path))
-
-(unless (system shell-cmd)
-  (error 'docker-run-transcript-matrix "container run failed"))
+(run/container->transcript
+ #:image image-tag
+ #:command (list "bash" "/work/test/e2e-transcript-matrix-container.sh")
+ #:transcript-path transcript-path
+ #:header header
+ #:home "/tmp/rackup-transcript-home"
+ #:volumes (list (format "~a:/work" (path->string root-dir)))
+ #:env-vars (standard-container-env #:home "/tmp/rackup-transcript-home" #:trace trace))
 
 (printf "Transcript written to ~a\n" transcript-path)

--- a/test/e2e-fresh-container.sh
+++ b/test/e2e-fresh-container.sh
@@ -23,7 +23,6 @@ export HOME="$TEST_HOME"
 # are not substituted. RACKUP_TESTING allows the bootstrap to proceed without them.
 export RACKUP_TESTING=1
 export TMPDIR="${TMPDIR:-/tmp}"
-export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 RUN_SRC="${TMPDIR}/rackup-src"
 PKG_SRC_ROOT="${TMPDIR}/rackup-e2e-pkgs"
 
@@ -63,28 +62,7 @@ assert_nonempty() {
   [[ -n "$value" ]] || fail "$msg"
 }
 
-echo "== Container environment =="
-echo "mode=$MODE"
-echo "specs=$SPECS_CSV"
-echo "snapshot_site=$SNAPSHOT_SITE"
-echo "local_link_mode=$LOCAL_LINK_MODE"
-echo "skip_package_tests=$SKIP_PACKAGE_TESTS"
-echo "host_racket_mode=$HOST_RACKET"
-if [[ "$LOCAL_LINK_MODE" == "build" ]]; then
-  echo "source_build_repo=$SOURCE_BUILD_REPO"
-  echo "source_build_ref=$SOURCE_BUILD_REF"
-  echo "source_build_commit=${SOURCE_BUILD_COMMIT:-}"
-  echo "source_build_target=$SOURCE_BUILD_TARGET"
-  echo "source_build_jobs=$SOURCE_BUILD_JOBS"
-  echo "prebuilt_local_source_dir=${PREBUILT_LOCAL_SOURCE_DIR:-}"
-fi
-echo "HOME=$HOME"
-echo "PWD=$(pwd)"
 host_racket_path="$(command -v racket || true)"
-echo "host-racket=${host_racket_path:-<missing>}"
-if [[ -n "$host_racket_path" ]]; then
-  racket -v || true
-fi
 
 if [[ "$MODE" == "direct" && "$HOST_RACKET" == "absent" ]]; then
   fail "direct mode requires a host racket; use --mode bootstrap for host-racket absent"

--- a/test/e2e-transcript-matrix-container.sh
+++ b/test/e2e-transcript-matrix-container.sh
@@ -13,7 +13,6 @@ INSTALL_TIMEOUT="${RACKUP_TRANSCRIPT_INSTALL_TIMEOUT:-900}"
 UNINSTALL_AT_END="${RACKUP_TRANSCRIPT_UNINSTALL_AT_END:-1}"
 
 export TMPDIR="${TMPDIR:-/tmp}"
-export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 export RACKUP_HOME
 
 note() {


### PR DESCRIPTION
### Motivation

- Consolidate Docker E2E orchestration in Racket so container shell scripts only implement scenario steps and to standardize transcript metadata, env assembly, and docker invocation plumbing.

### Description

- Add an "E2E architecture" section to `docs/IMPLEMENTATION.md` describing Racket orchestration vs container script responsibilities.
- Refactor `test/docker-e2e.rkt` to use `remote-shell/ssh`, introduce `sh-quote`, `run/remote-shell-check`, `current-utc-stamp`, `git-head-commit`, `transcript-header`, `standard-container-env`, `docker-run-argv`, and `run/container->transcript`, and switch docker build/run calls to those helpers.
- Update `test/docker-run-transcript-matrix.rkt` to generate standardized transcript headers and call `run/container->transcript` instead of ad-hoc shell pipelines.
- Tidy container scripts (`test/e2e-fresh-container.sh`, `test/e2e-transcript-matrix-container.sh`) by removing duplicated PATH overrides and noisy environment prints so orchestration provides those values.

### Testing

- Ran unit tests via `raco test test/versioning.rkt test/remote.rkt test/state-shims.rkt` which completed successfully.
- Built a Docker E2E image and executed `test/docker-run-transcript-matrix.rkt` to generate a transcript file using the new helpers, and the run completed and produced the expected transcript.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f671fcb294832897c170da93ed3936)