### PR TITLE
Deduplicate core logic, adopt stdlib helpers, extract reusable abstractions

### DIFF
--- a/bin/rackup
+++ b/bin/rackup
@@ -54,10 +54,9 @@ if [ "${1:-}" = "help" ] && [ "${2:-}" = "prompt" ] && [ "$#" -eq 2 ]; then
   exit 0
 fi
 
-# --- Prebuilt binary path: if rackup-core binary exists, use it directly ---
-if [ -x "$CORE_EXE" ]; then
-  # Save user's Racket env vars for pass-through (rackup run), then clear
-  # so the embedded runtime is not affected.
+# Save user's Racket env vars for pass-through (rackup run), then clear
+# so rackup's own runtime (embedded exe or hidden runtime) is not affected.
+rackup_save_and_clear_racket_env() {
   for _rackup_v in PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK; do
     eval "_rackup_val=\${$_rackup_v:-}"
     if [ -n "$_rackup_val" ]; then
@@ -65,7 +64,11 @@ if [ -x "$CORE_EXE" ]; then
     fi
   done
   unset PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK
+}
 
+# --- Prebuilt binary path: if rackup-core binary exists, use it directly ---
+if [ -x "$CORE_EXE" ]; then
+  rackup_save_and_clear_racket_env
   exec "$CORE_EXE" "$@"
 fi
 # --- End prebuilt binary path ---
@@ -80,23 +83,7 @@ else
   USE_Y=1
 fi
 rackup_mkdir_p "$RUNTIME_ADDON_DIR"
-# Save user's Racket env vars for pass-through (rackup run), then clear
-# so the hidden runtime is not affected.
-for _rackup_v in PLTHOME PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK; do
-  eval "_rackup_val=\${$_rackup_v:-}"
-  if [ -n "$_rackup_val" ]; then
-    eval "export _RACKUP_ORIG_$_rackup_v=\"\$_rackup_val\""
-  fi
-done
-unset PLTCOLLECTS PLTADDONDIR PLTCOMPILEDROOTS PLTUSERHOME RACKET_XPATCH PLT_COMPILED_FILE_CHECK
-
-rackup_run_core() {
-  if [ "$USE_Y" -eq 1 ]; then
-    "$RACKET_EXE" -y -U -A "$RUNTIME_ADDON_DIR" "$CORE" "$@"
-  else
-    "$RACKET_EXE" -U -A "$RUNTIME_ADDON_DIR" "$CORE" "$@"
-  fi
-}
+rackup_save_and_clear_racket_env
 
 # Uninstall: the Racket code handles confirmation and RC cleanup but does
 # NOT delete RACKUP_HOME. The wrapper does the rm -rf after Racket exits,

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -74,17 +74,18 @@ All rackup state lives under `RACKUP_HOME` (default `~/.rackup`). The layout is 
 
 ### Index
 
-`~/.rackup/state/index.rktd` is the toolchain registry. It is a Racket hash with three keys:
+`~/.rackup/state/index.rktd` is the toolchain registry. It is a Racket hash with two keys:
 
 - `installed-toolchains`: hash from toolchain ID to a metadata summary.
-- `aliases`: hash from short names to toolchain IDs.
 - `default-toolchain`: the default toolchain ID or `#f`.
+
+Unknown keys in an existing index file are dropped on the next save; missing keys are filled with defaults, so the format can evolve in either direction.
 
 The default toolchain is also stored separately in `~/.rackup/state/default-toolchain` as a plain text file. The separate file exists so that shell code can read the default without parsing `.rktd` format. The Racket code reads both and prefers the file.
 
 ### Config file
 
-`~/.rackup/state/config` is a plain-text file with one flag name per line. It stores boolean configuration flags such as `short-aliases`. The `config-flag-set?`, `set-config-flag!`, and `clear-config-flag!` functions in `state.rkt` manage it. This replaced the earlier approach of separate marker files (e.g., `state/shim-aliases`) and a `config.rktd` hash; the plain-text format is simpler to inspect and edit.
+`~/.rackup/state/config` is a plain-text file with one flag name per line. It stores boolean configuration flags such as `short-aliases`. The `config-flag-set?`, `set-config-flag!`, and `clear-config-flag!` functions in `state.rkt` manage it.
 
 ### Per-toolchain metadata
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -139,7 +139,7 @@ At toolchain install or link time, `compiled-roots-value` in `state.rkt` constru
 
 The `'same` symbol in `current-compiled-file-roots` cannot be spelled directly in PLTCOMPILEDROOTS because `path-list-string->path-list` converts all entries to path objects. However, `.` is a relative path that `(build-path dir ".")` resolves to `dir` itself, which is functionally equivalent.
 
-For linked toolchains where version or variant cannot be probed, PLTCOMPILEDROOTS is omitted. The value flows through the existing `env-vars` metadata pipeline: `write-env-file!`/`write-toolchain-env-file!` emits an unconditional export in env.sh, and `cmd-run` in `main.rkt` preserves a user-restored value before overlaying toolchain env vars.
+For linked toolchains where version or variant cannot be probed, PLTCOMPILEDROOTS is omitted. The value flows through the existing `env-vars` metadata pipeline: `write-toolchain-env-file!` (in `shims.rkt`) emits an unconditional export in env.sh, and `cmd-run` in `main.rkt` preserves a user-restored value before overlaying toolchain env vars.
 
 ### Migration for existing installs
 

--- a/docs/plans/2026-06-09-dedup-and-stdlib-refactor.md
+++ b/docs/plans/2026-06-09-dedup-and-stdlib-refactor.md
@@ -76,6 +76,44 @@ New reusable abstractions:
   `runtime.rkt`).
 - `text.rkt`: `yes-answer?` for interactive `[y/N]`/`[Y/n]` prompts.
 
+## Phase 3: needless defensiveness and dead feature code (2026-06-10)
+
+A follow-up pass hunting redundant error handling and unnecessary code:
+
+- **Removed the index `aliases` map entirely.** No command ever wrote an
+  alias — the map was always empty — yet `resolve-name-with-meta`,
+  `find-local-toolchain`, and `toolchain-short-names` all carried alias
+  plumbing. An old index containing the key still loads (normalize-index
+  drops unknown keys).
+- **Removed the legacy `config.rktd`/`shim-aliases` migrations** in
+  `ensure-index!` and their path accessors. Those formats existed only
+  between 2026-02-26 and 2026-03-17; any install touched since then has
+  already migrated.
+- **Removed the hash form of `meta->env-vars`.** env-vars was written as
+  a list-of-lists from the first commit that introduced it; the hash
+  branch never had a writer.
+- **Removed the unreachable "failed to remove existing toolchain"
+  checks** after `delete-toolchain-dir!` in install/link: deletion
+  failures raise on their own.
+- **remote.rkt restructure:** the request hash construction
+  (`install-request-hash`), download-page checksum attachment
+  (`attach-page-checksum`), and full→minimal retry
+  (`try-with-minimal-fallback`) were each written out two to four times
+  across the release/pre-release/snapshot resolvers; each is now one
+  helper.
+- **Shared `installer-platform-fields`** (versioning.rkt): the
+  platform-token decomposition duplicated between
+  `parse-installer-filename` (remote.rkt) and
+  `parse-legacy-installer-filename` (legacy.rkt).
+- **versioning.rkt:** `version-token->number`'s four-way match collapsed
+  via zero-padding; `arch-token->normalized`'s identity branches dropped
+  (only arm64 and the ppc family actually map to something else).
+- Smaller: `upgradeable-toolchains` read each meta.rktd twice; dropped
+  the `version-maybe-plt-scheme?` alias, the `ansi-color` and
+  `install-verbosity` pass-through wrappers, a `(hash? m)` guard after
+  `(filter hash? ...)`, and `find-orphan-toolchain-id`'s split
+  unique/ambiguous helpers.
+
 ## Test-suite coverage fix
 
 `test/all.rkt` required each test file's *main* module, but every test

--- a/docs/plans/2026-06-09-dedup-and-stdlib-refactor.md
+++ b/docs/plans/2026-06-09-dedup-and-stdlib-refactor.md
@@ -1,0 +1,99 @@
+# Deduplication, stdlib, and reusable-abstraction refactor
+
+Date: 2026-06-09
+
+A codebase-wide simplification pass in two phases: (1) eliminate
+copy-paste duplication, (2) replace hand-rolled code with Racket
+standard-library equivalents and extract cross-cutting patterns into
+reusable helpers (in the spirit of `lock.rkt`'s `define-file-lock`).
+
+## Phase 1: deduplication
+
+- `ensure-installer-cached!` and its cache-path helper existed nearly
+  verbatim in both `install.rkt` and `runtime.rkt`. Now one copy in
+  `installer-backend.rkt` with an `#:announce` hook for the differing
+  progress messages.
+- The env.sh writer/deleter pair was duplicated between `install.rkt`
+  and `shims.rkt`. The `shims.rkt` version (which skips rewriting
+  unchanged files) is the only one left, plus
+  `sync-toolchain-env-file!` replacing the write-or-delete conditional
+  repeated at three call sites.
+- `toolchain-runtime-env` (install.rkt) and `toolchain-runtime-env-vars`
+  (main.rkt) were identical; now one function in `state.rkt`, along
+  with `toolchain-env-var-entries` (the PLTADDONDIR/PLTCOMPILEDROOTS
+  entry construction, previously written out in both `install.rkt` and
+  `shims.rkt`) and `env-vars->meta`.
+- `scripts/install.sh` had ~140 lines of copy-pasted binary-install
+  logic between the GitHub-CI-artifact path and the published-binary
+  path; both now call `install_binary_distribution()` (which also
+  brings the macOS ad-hoc codesign step to the CI-artifact path, fixing
+  a gap). Also extracted: `extract_tarball_dir()` (three sites),
+  `download_stdout()`, `reshim_and_store_checksum()`; the inline
+  `copy_filtered_tree` now invokes the bundled
+  `scripts/copy-filtered-tree.sh` (the source tarball ships it for
+  exactly this step).
+- `bin/rackup`'s two save-and-unset Racket-env blocks became one
+  helper; removed the dead `rackup_run_core` function and the vestigial
+  `PLTHOME` save (nothing restores `_RACKUP_ORIG_PLTHOME`).
+- The `_rackup_toolchains` shell function duplicated across the bash
+  and zsh completion templates is now a shared include
+  (`templates/toolchains-fn.scrbl`).
+- `test/state-shims.rkt` (2662 → 2488 lines): `write-fake-exe!`
+  replaces ~45 write+chmod pairs; `test-toolchain-meta` replaces ~19
+  verbose metadata hash literals and the four locally-reinvented
+  register helpers.
+
+## Phase 2: stdlib replacements and reusable abstractions
+
+Standard library:
+
+- `rktd-io.rkt` reimplemented `call-with-atomic-output-file`; it now
+  delegates to the `racket/file` version, keeping the
+  permission-preservation behavior (which the stdlib version lacks and
+  tests rely on) as a thin wrapper, `write-file-atomically`.
+- `split-on-double-dash` uses `splitf-at`; `usage-line` uses
+  `~a #:min-width`; the Chez-executable scoring in `install.rkt` uses
+  `argmax` (over a path-sorted list to keep the deterministic
+  tiebreak).
+- Checked but rejected: `version/utils` for `versioning.rkt` (rackup
+  must order PLT Scheme versions like `103`/`372` that `valid-version?`
+  rejects); `net/head`'s `extract-field` (headers arrive as a list of
+  byte strings from `http-sendrecv`, not a header block); `fold-files`
+  for `for-each-named-subdir` (the explicit walk is clearer than
+  encoding prune-on-match in fold-files' descend protocol).
+
+New reusable abstractions:
+
+- `error.rkt`: `try-or` — `(try-or default body ...)` for the
+  pervasive swallow-exn:fail-and-return-default pattern; 20 simple call
+  sites converted (sites whose handlers log or inspect the exception
+  keep explicit `with-handlers`).
+- `fs.rkt`: `delete-path!` (link/file/directory, no-op when absent) and
+  `dir-or-link-exists?`.
+- `process.rkt`: `call-with-env-overlay` (copied-environment overlay
+  for subprocess calls; used by `capture-program-output`, package
+  migration, and self-upgrade), and `run-quiet-program` (moved from
+  `runtime.rkt`).
+- `text.rkt`: `yes-answer?` for interactive `[y/N]`/`[Y/n]` prompts.
+
+## Test-suite coverage fix
+
+`test/all.rkt` required each test file's *main* module, but every test
+file wraps its checks in `(module+ test ...)` — so `raco test
+test/all.rkt` (what CI runs) executed only top-level checks: 316 of
+what are actually 955 tests. `all.rkt` now requires the `test`
+submodules. Latent bugs this exposed, all fixed:
+
+- `install.rkt` and `shell.rkt` used `#lang at-exp`, violating
+  `test/remote.rkt`'s no-at-exp-in-client-code invariant; both
+  converted to plain `racket/base` with byte-identical generated
+  output.
+- A `test/state-shims.rkt` test restored originally-unset env vars with
+  `(putenv name "")`; `putenv` cannot unset, so `PLTUSERHOME` was left
+  as the empty string, making `(find-system-path 'home-dir)` return `/`
+  for the rest of the process and breaking `test/uninstall.rkt`'s
+  safety checks. It now poisons a copied environment via
+  `parameterize` instead.
+- `test/rktd-io.rkt` called `compile` relying on the namespace `raco
+  test` happens to install; it now uses `make-base-namespace`.
+- `test/version.rkt` called `cmd-version` without its argument.

--- a/libexec/rackup/error.rkt
+++ b/libexec/rackup/error.rkt
@@ -1,6 +1,15 @@
 #lang racket/base
 
-(provide rackup-error)
+(provide rackup-error
+         try-or)
 
 (define (rackup-error fmt . args)
   (raise-user-error 'rackup (apply format fmt args)))
+
+;; Evaluate body, returning `default` if it raises exn:fail.  For the
+;; pervasive "best effort, fall back to a default" pattern; use a full
+;; with-handlers form when the handler needs to log or inspect the
+;; exception.
+(define-syntax-rule (try-or default body ...)
+  (with-handlers ([exn:fail? (lambda (_) default)])
+    body ...))

--- a/libexec/rackup/fs.rkt
+++ b/libexec/rackup/fs.rkt
@@ -3,22 +3,29 @@
 (require racket/file)
 
 (provide ensure-directory*
+         delete-path!
+         dir-or-link-exists?
          replace-path!)
 
 (define (ensure-directory* p)
   (make-directory* p)
   p)
 
+;; Delete whatever is at `p` — link, file, or directory.  A no-op when
+;; nothing exists there.
+(define (delete-path! p)
+  (cond
+    [(or (link-exists? p) (file-exists? p)) (delete-file p)]
+    [(directory-exists? p) (delete-directory/files p)]))
+
+(define (dir-or-link-exists? p)
+  (or (link-exists? p) (directory-exists? p)))
+
 ;; Replace whatever is at `dest` (link, file, or directory) with `src`,
 ;; using `mode` to choose how to materialize `src`. The destination is
 ;; cleared first; if creation fails, `dest` is left absent.
 (define (replace-path! dest src #:mode [mode 'link])
-  (when (link-exists? dest)
-    (delete-file dest))
-  (when (file-exists? dest)
-    (delete-file dest))
-  (when (directory-exists? dest)
-    (delete-directory/files dest))
+  (delete-path! dest)
   (case mode
     [(link) (make-file-or-directory-link src dest)]
     [(file) (copy-file src dest #t)]

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -1,4 +1,4 @@
-#lang at-exp racket/base
+#lang racket/base
 
 (require racket/cmdline
          racket/file
@@ -110,29 +110,10 @@
                          (path->string* p)))
          p)))
 
-(define (installer-cache-file installer-url)
-  (build-path (rackup-download-cache-dir)
-              (path-basename-string (string->path (car (reverse (string-split installer-url "/")))))))
-
-(define (ensure-installer-cached! installer-url
-                                  #:no-cache? [no-cache? #f]
-                                  #:sha256 [expected-sha256 #f]
-                                  #:sha1 [expected-sha1 #f])
-  (ensure-rackup-layout!)
-  (require-checksummed-http-installer! installer-url expected-sha256)
-  (define cache-path (installer-cache-file installer-url))
-  (when (and (file-exists? cache-path) (or expected-sha256 expected-sha1))
-    (with-handlers ([exn:fail? (lambda (_)
-                                 (delete-file cache-path))])
-      (verify-installer-checksum! cache-path #:sha256 expected-sha256 #:sha1 expected-sha1)))
-  (when (or no-cache? (not (file-exists? cache-path)))
-    (if (install-verbose?)
-        (install-verbose "Downloading installer: ~a" installer-url)
-        (install-info "Downloading installer..."))
-    (download-url->file installer-url cache-path)
-    (verify-installer-checksum! cache-path #:sha256 expected-sha256 #:sha1 expected-sha1)
-    (file-or-directory-permissions cache-path #o755))
-  cache-path)
+(define (announce-installer-download url)
+  (if (install-verbose?)
+      (install-verbose "Downloading installer: ~a" url)
+      (install-info "Downloading installer...")))
 
 (define (run-linux-installer! installer-file
                               install-root
@@ -143,7 +124,7 @@
   (install-verbose "Installing into ~a" (path->string dest))
   (define log-file (make-temporary-file "rackup-installer-~a.log"))
   (define (delete-log!)
-    (with-handlers ([exn:fail? (lambda (_) (void))])
+    (try-or (void)
       (delete-file log-file)))
   (define detected-shell-mode
     (and (regexp-match? #px"[.]sh$" (string-downcase (path->string* installer)))
@@ -175,7 +156,7 @@
              (run-modern))))))
   (unless ok?
     (define details
-      (with-handlers ([exn:fail? (lambda (_) "")])
+      (try-or ""
         (call-with-input-file* log-file (lambda (in) (string-trim (port->string in))))))
     (install-warn "Installer script failed.")
     (unless (string-blank? details)
@@ -190,7 +171,7 @@
 
 (define (file-executable?/safe p)
   (and (file-exists? p)
-       (with-handlers ([exn:fail? (lambda (_) #f)])
+       (try-or #f
          (member 'execute (file-or-directory-permissions p)))))
 
 (define (enumerate-toolchain-executables real-bin-dir)
@@ -212,10 +193,7 @@
 
 (define (make-bin-overlay! id real-bin-dir extra-exes)
   (define overlay (rackup-toolchain-bin-link id))
-  (cond
-    [(link-exists? overlay) (delete-file overlay)]
-    [(file-exists? overlay) (delete-file overlay)]
-    [(directory-exists? overlay) (delete-directory/files overlay)])
+  (delete-path! overlay)
   (make-directory* overlay)
   (for ([p (in-list (directory-list real-bin-dir #:build? #t))]
         #:when (and (file-exists? p) (file-executable?/safe p)))
@@ -257,10 +235,9 @@
   (define quoted-args (string-join (map sh-single-quote args) " "))
   (define args-suffix (if (equal? quoted-args "") "" (string-append " " quoted-args)))
   (define body
-    @~a{#!/usr/bin/env bash
-        set -euo pipefail
-        exec @|quoted-exe|@|args-suffix| "$@"@""
-        })
+    (string-append "#!/usr/bin/env bash\n"
+                   "set -euo pipefail\n"
+                   "exec " quoted-exe args-suffix " \"$@\"\n"))
   (write-string-file dest body)
   (file-or-directory-permissions dest #o755))
 
@@ -273,26 +250,8 @@
     (define src (assoc name extra-exes))
     (when src
       (define dest (build-path overlay name))
-      (when (or (link-exists? dest) (file-exists? dest))
-        (delete-file dest))
+      (delete-path! dest)
       (write-exec-wrapper! dest (cdr src) boot-args))))
-
-(define (write-toolchain-env-file! id env-vars)
-  (define p (rackup-toolchain-env-file id))
-  (define body
-    (string-append "#!/usr/bin/env bash\n"
-                   "# rackup managed toolchain environment\n"
-                   (apply string-append
-                          (for/list ([kv (in-list env-vars)])
-                            (env-var-export-line (car kv) (cdr kv))))))
-  (write-string-file p body)
-  (file-or-directory-permissions p #o644)
-  p)
-
-(define (delete-toolchain-env-file! id)
-  (define p (rackup-toolchain-env-file id))
-  (when (file-exists? p)
-    (delete-file p)))
 
 (define (path-complete-string p)
   (path->string* (path->complete-path p)))
@@ -362,28 +321,24 @@
               (set! names->paths (make-hash))
               (hash-set! dirs->executables dir names->paths))
             (hash-set! names->paths (path-basename-string p) p)))
-        (let* ([scored (for/list ([dir (in-list (hash-keys dirs->executables))])
-                         (define names->paths (hash-ref dirs->executables dir))
-                         (define both?
-                           (and (hash-has-key? names->paths "scheme")
-                                (hash-has-key? names->paths "petite")))
-                         (define score
-                           (+ (if both? 200 0)
-                              (if (path-contains? dir #rx"/src/build/") 100 0)
-                              (if (path-contains? dir #rx"/ChezScheme/") 40 0)
-                              (if (path-contains? dir #rx"/bin/") 20 0)))
-                         (list dir names->paths score (path->string* dir)))]
-               [best (car (sort scored
-                                (lambda (a b)
-                                  (define sa (list-ref a 2))
-                                  (define sb (list-ref b 2))
-                                  (define pa (list-ref a 3))
-                                  (define pb (list-ref b 3))
-                                  (or (> sa sb) (and (= sa sb) (string<? pa pb))))))]
-               [names->paths (list-ref best 1)])
-          (for/list ([name (in-list chez-extra-names)]
-                     #:when (hash-has-key? names->paths name))
-            (cons name (hash-ref names->paths name)))))))
+        (define (dir-score dir)
+          (define names->paths (hash-ref dirs->executables dir))
+          (define both?
+            (and (hash-has-key? names->paths "scheme")
+                 (hash-has-key? names->paths "petite")))
+          (+ (if both? 200 0)
+             (if (path-contains? dir #rx"/src/build/") 100 0)
+             (if (path-contains? dir #rx"/ChezScheme/") 40 0)
+             (if (path-contains? dir #rx"/bin/") 20 0)))
+        ;; Sort by path first so argmax (which keeps the first maximum)
+        ;; breaks score ties deterministically.
+        (define best
+          (argmax dir-score
+                  (sort (hash-keys dirs->executables) string<? #:key path->string*)))
+        (define names->paths (hash-ref dirs->executables best))
+        (for/list ([name (in-list chez-extra-names)]
+                   #:when (hash-has-key? names->paths name))
+          (cons name (hash-ref names->paths name))))))
 
 (define (detect-local-source-layout path-input)
   (define input-path
@@ -488,22 +443,12 @@
   ;; tends to be wrong for users whose packages live in their native
   ;; addon-dir (e.g., ~/.local/share/racket/<install-name>/), and the
   ;; old behavior caused silent breakage of `raco pkg` operations.
-  (define addon-entry
-    (if (and (string? addon-dir) (not (string-blank? addon-dir)))
-        (list (cons "PLTADDONDIR" addon-dir))
-        null))
   (define bin-dir-str (hash-ref layout 'bin-dir #f))
   (define existing-roots
     (if bin-dir-str
         (read-toolchain-compiled-file-roots (string->path bin-dir-str))
         '(same)))
-  (define compiled-roots-entry
-    (cond
-      [(compiled-roots-value version variant existing-roots local-name)
-       =>
-       (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
-      [else null]))
-  (append addon-entry compiled-roots-entry))
+  (toolchain-env-var-entries addon-dir version variant existing-roots local-name))
 
 ;; Old PLT Scheme installations (version <= 4.x) have a shell wrapper at
 ;; plt/bin/mzscheme that uses $PLTHOME to locate the real binary under
@@ -524,14 +469,13 @@
        (list (cons "PLTHOME" (path->string* plthome-normalized)))]
       [else null]))
   (define compiled-roots-entry
-    (cond
-      [(and (hash? request)
-            (compiled-roots-value (hash-ref request 'resolved-version #f)
-                                  (hash-ref request 'variant #f)
-                                  (read-toolchain-compiled-file-roots real-bin-dir)))
-       =>
-       (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
-      [else null]))
+    (if (hash? request)
+        (toolchain-env-var-entries #f
+                                   (hash-ref request 'resolved-version #f)
+                                   (hash-ref request 'variant #f)
+                                   (read-toolchain-compiled-file-roots real-bin-dir)
+                                   #f)
+        null))
   (append plthome-entry compiled-roots-entry))
 
 (define (toolchain-meta request id real-bin-dir executables [env-vars null] [prefix #f])
@@ -570,8 +514,7 @@
         'toolchain-prefix
         (and prefix (path->string* prefix))
         'env-vars
-        (for/list ([kv (in-list env-vars)])
-          (list (car kv) (cdr kv)))
+        (env-vars->meta env-vars)
         'executables
         executables
         'installed-at
@@ -703,8 +646,7 @@
         'real-bin-dir
         (path->string* real-bin-dir)
         'env-vars
-        (for/list ([kv (in-list env-vars)])
-          (list (car kv) (cdr kv)))
+        (env-vars->meta env-vars)
         'executables
         executables
         'installed-at
@@ -720,7 +662,7 @@
   (define tc-dir (rackup-toolchain-dir id))
   (when (hash-ref parsed-opts 'force? #f)
     (delete-toolchain-dir! tc-dir)
-    (when (or (link-exists? tc-dir) (directory-exists? tc-dir))
+    (when (dir-or-link-exists? tc-dir)
       (rackup-error "failed to remove existing toolchain before relink: ~a" id)))
   (define layout (detect-local-source-layout local-path))
   (define real-bin-dir (string->path (hash-ref layout 'bin-dir)))
@@ -729,7 +671,7 @@
     (rackup-error "linked toolchain does not contain an executable racket binary at ~a"
                   (path->string* racket-exe)))
   (cond
-    [(or (link-exists? tc-dir) (directory-exists? tc-dir))
+    [(dir-or-link-exists? tc-dir)
      (rackup-error "toolchain already exists: ~a (use --force to relink)" id)]
     [else
      (with-handlers ([exn:fail? (lambda (e)
@@ -769,9 +711,7 @@
   (define env-vars (local-layout-env-vars layout addon-dir* version* variant* name))
   (make-bin-overlay! id real-bin-dir extra-exes)
   (maybe-wrap-local-chez-extra-executables! id extra-exes layout)
-  (if (pair? env-vars)
-      (write-toolchain-env-file! id env-vars)
-      (delete-toolchain-env-file! id))
+  (sync-toolchain-env-file! id env-vars)
   (ensure-toolchain-addon-dir! id)
   (define executables (enumerate-toolchain-executables (rackup-toolchain-bin-link id)))
   (define base-meta
@@ -844,9 +784,7 @@
                (hash-ref request 'arch)
                (hash-ref request 'platform))
        (flush-output)
-       (define answer (read-line))
-       (unless (and (string? answer)
-                    (member (string-downcase (string-trim answer)) '("y" "yes")))
+       (unless (yes-answer? (read-line))
          (rackup-error "install aborted"))]
       [else
        ;; Default full was unavailable; proceed with warning
@@ -862,7 +800,7 @@
     (define explicit-default? (hash-ref parsed-opts 'set-default? #f))
     (when (hash-ref parsed-opts 'force? #f)
       (delete-toolchain-dir! tc-dir)
-      (when (or (link-exists? tc-dir) (directory-exists? tc-dir))
+      (when (dir-or-link-exists? tc-dir)
         (rackup-error "failed to remove existing toolchain before reinstall: ~a" id)))
     ;; A dangling --prefix symlink (target wiped, e.g., /tmp cleared) or a
     ;; ghost dir from an interrupted install would block the reinstall;
@@ -885,7 +823,8 @@
          (ensure-installer-cached! (hash-ref request 'installer-url)
                                    #:no-cache? (hash-ref parsed-opts 'no-cache? #f)
                                    #:sha256 (hash-ref request 'installer-sha256 #f)
-                                   #:sha1 (hash-ref request 'installer-sha1 #f)))
+                                   #:sha1 (hash-ref request 'installer-sha1 #f)
+                                   #:announce announce-installer-download))
        (define installer-ext
          (detect-installer-type
           (hash-ref request
@@ -899,7 +838,7 @@
          (cond
            [prefix
             (define real (build-path prefix id))
-            (when (or (link-exists? real) (directory-exists? real))
+            (when (dir-or-link-exists? real)
               (rackup-error
                (string-append
                 "refusing to install ~a into existing prefix path: ~a\n"
@@ -932,9 +871,7 @@
          (maybe-modernize-legacy-archsys! real-bin-dir)
          (make-bin-link! id real-bin-dir)
          (define env-vars (installed-toolchain-env-vars real-bin-dir request))
-         (if (pair? env-vars)
-             (write-toolchain-env-file! id env-vars)
-             (delete-toolchain-env-file! id))
+         (sync-toolchain-env-file! id env-vars)
          (ensure-toolchain-addon-dir! id)
          (define executables (enumerate-toolchain-executables real-bin-dir))
          (define meta (toolchain-meta request id real-bin-dir executables env-vars prefix))
@@ -964,12 +901,6 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Upgrade
-
-;; Build the environment variable alist for running a toolchain's raco.
-(define (toolchain-runtime-env id)
-  (append (toolchain-env-vars id)
-          (list (cons "PLTADDONDIR"
-                      (path->string (rackup-addon-dir id))))))
 
 ;; Run raco with the correct env for a toolchain.  Returns stdout as a
 ;; string on success, #f on failure.
@@ -1015,7 +946,7 @@
 ;; or #f if the toolchain's racket cannot be invoked.
 (define (toolchain-user-package-dirs id)
   (define out
-    (with-handlers ([exn:fail? (lambda (_) #f)])
+    (try-or #f
       (capture-racket-eval-output id list-pkg-dirs-program)))
   (cond
     [(or (not out) (string-blank? out)) null]
@@ -1030,7 +961,7 @@
 (define (for-each-named-subdir root target proc)
   (define (walk dir)
     (when (and (directory-exists? dir) (not (link-exists? dir)))
-      (for ([entry (in-list (with-handlers ([exn:fail? (lambda (_) null)])
+      (for ([entry (in-list (try-or null
                               (directory-list dir #:build? #t)))])
         (cond
           [(link-exists? entry) (void)]
@@ -1132,14 +1063,11 @@
                    (string-join pkgs " "))
      (define bin (rackup-toolchain-bin-link new-id))
      (define raco-exe (build-path bin "raco"))
-     (define env (environment-variables-copy (current-environment-variables)))
-     (for ([kv (in-list (toolchain-runtime-env new-id))])
-       (environment-variables-set! env
-                                   (string->bytes/utf-8 (car kv))
-                                   (string->bytes/utf-8 (cdr kv))))
      (define ok?
-       (parameterize ([current-environment-variables env])
-         (apply system* raco-exe "pkg" "install" "--auto" "--skip-installed" pkgs)))
+       (call-with-env-overlay
+        (toolchain-runtime-env new-id)
+        (lambda ()
+          (apply system* raco-exe "pkg" "install" "--auto" "--skip-installed" pkgs))))
      (cond
        [ok?
         (install-ok "Migrated ~a package~a."
@@ -1333,8 +1261,6 @@
 (module+ for-testing
   (provide discover-bin-dir
            installed-toolchain-env-vars
-           ensure-installer-cached!
            parse-pkg-show-output
            meta->upgrade-spec
-           write-toolchain-env-file!
            clean-toolchain-compiled-dirs!))

--- a/libexec/rackup/install.rkt
+++ b/libexec/rackup/install.rkt
@@ -49,31 +49,25 @@
 
 (define current-install-verbosity (make-parameter 'normal))
 
-(define (install-verbosity)
-  (current-install-verbosity))
-
 (define (install-quiet?)
-  (eq? (install-verbosity) 'quiet))
+  (eq? (current-install-verbosity) 'quiet))
 
 (define (install-verbose?)
-  (eq? (install-verbosity) 'verbose))
-
-(define (ansi-color code s)
-  (ansi code s))
+  (eq? (current-install-verbosity) 'verbose))
 
 (define (install-info fmt . args)
   (unless (install-quiet?)
-    (displayln (ansi-color "34" (apply format fmt args)))))
+    (displayln (ansi "34" (apply format fmt args)))))
 
 (define (install-ok fmt . args)
-  (displayln (ansi-color "32" (apply format fmt args))))
+  (displayln (ansi "32" (apply format fmt args))))
 
 (define (install-warn fmt . args)
-  (eprintf "~a\n" (ansi-color "33" (apply format fmt args))))
+  (eprintf "~a\n" (ansi "33" (apply format fmt args))))
 
 (define (install-verbose fmt . args)
   (when (install-verbose?)
-    (displayln (ansi-color "34" (apply format fmt args)))))
+    (displayln (ansi "34" (apply format fmt args)))))
 
 (define (truncate-lines s [max-lines 80])
   (define lines (string-split s "\n"))
@@ -661,9 +655,7 @@
   (define id (local-toolchain-id name))
   (define tc-dir (rackup-toolchain-dir id))
   (when (hash-ref parsed-opts 'force? #f)
-    (delete-toolchain-dir! tc-dir)
-    (when (dir-or-link-exists? tc-dir)
-      (rackup-error "failed to remove existing toolchain before relink: ~a" id)))
+    (delete-toolchain-dir! tc-dir))
   (define layout (detect-local-source-layout local-path))
   (define real-bin-dir (string->path (hash-ref layout 'bin-dir)))
   (define racket-exe (build-path real-bin-dir "racket"))
@@ -799,9 +791,7 @@
     (define default-before (get-default-toolchain))
     (define explicit-default? (hash-ref parsed-opts 'set-default? #f))
     (when (hash-ref parsed-opts 'force? #f)
-      (delete-toolchain-dir! tc-dir)
-      (when (dir-or-link-exists? tc-dir)
-        (rackup-error "failed to remove existing toolchain before reinstall: ~a" id)))
+      (delete-toolchain-dir! tc-dir))
     ;; A dangling --prefix symlink (target wiped, e.g., /tmp cleared) or a
     ;; ghost dir from an interrupted install would block the reinstall;
     ;; clean either up here.

--- a/libexec/rackup/installer-backend.rkt
+++ b/libexec/rackup/installer-backend.rkt
@@ -5,11 +5,16 @@
          racket/path
          racket/string
          racket/system
+         "checksum.rkt"
          "error.rkt"
+         "paths.rkt"
          "process.rkt"
+         "remote.rkt"
+         "security.rkt"
          "text.rkt")
 
 (provide detect-installer-type
+         ensure-installer-cached!
          extract-tgz-installer!
          install-from-dmg!
          discover-bin-dir)
@@ -39,6 +44,34 @@
     [else #f]))
 
 (define (tar-exe) (find-executable-path/default "tar" "/bin/tar"))
+
+(define (installer-cache-path installer-url)
+  (build-path (rackup-download-cache-dir)
+              (path-basename-string (string->path (last (string-split installer-url "/"))))))
+
+;; Download an installer into the shared download cache, verifying its
+;; checksum, and return the cached path.  A cached file whose checksum
+;; no longer matches is deleted and redownloaded; `#:no-cache?` forces a
+;; redownload.  `#:announce` is called with the URL before downloading.
+(define (ensure-installer-cached! installer-url
+                                  #:no-cache? [no-cache? #f]
+                                  #:sha256 [expected-sha256 #f]
+                                  #:sha1 [expected-sha1 #f]
+                                  #:announce [announce
+                                              (lambda (url)
+                                                (displayln (format "Downloading installer: ~a" url)))])
+  (ensure-rackup-layout!)
+  (require-checksummed-http-installer! installer-url expected-sha256)
+  (define cache-path (installer-cache-path installer-url))
+  (when (and (file-exists? cache-path) (or expected-sha256 expected-sha1))
+    (with-handlers ([exn:fail? (lambda (_) (delete-file cache-path))])
+      (verify-installer-checksum! cache-path #:sha256 expected-sha256 #:sha1 expected-sha1)))
+  (when (or no-cache? (not (file-exists? cache-path)))
+    (announce installer-url)
+    (download-url->file installer-url cache-path)
+    (verify-installer-checksum! cache-path #:sha256 expected-sha256 #:sha1 expected-sha1)
+    (file-or-directory-permissions cache-path #o755))
+  cache-path)
 
 ;; Extract a .tgz installer archive into install-root.
 ;; `#:check-label` sets the error-context label; `#:archive-noun` and

--- a/libexec/rackup/legacy.rkt
+++ b/libexec/rackup/legacy.rkt
@@ -25,7 +25,6 @@
          plt-version->hyphenated
          select-plt-generated-page-url
          plt-generated-page-url->installer-filename
-         version-maybe-plt-scheme?
          legacy-interactive-linux-installer?
          detect-shell-installer-mode
          legacy-installer-input-script
@@ -56,67 +55,28 @@
 (define (parse-legacy-installer-filename s)
   (match (regexp-match legacy-installer-rx s)
     [(list _ prefix version-token platform-token ext-s)
-     (define distribution (if (equal? prefix "racket-textual") 'minimal 'full))
-     (define parts (string-split platform-token "-"))
-     (define arch-token
-       (if (pair? parts)
-           (car parts)
-           platform-token))
-     (define platform-parts
-       (if (>= (length parts) 2)
-           (cdr parts)
-           null))
-     (define platform
-       (if (pair? platform-parts)
-           (string-join platform-parts "-")
-           ""))
-     (define platform-family
-       (if (pair? platform-parts)
-           (car platform-parts)
-           platform))
-     (hash 'filename
-           s
-           'distribution
-           distribution
-           'version-token
-           version-token
-           'platform-token
-           platform-token
-           'arch-token
-           arch-token
-           'arch
-           (arch-token->normalized arch-token)
-           'platform
-           platform
-           'platform-family
-           platform-family
-           'platform-parts
-           platform-parts
-           'variant
-           'bc
-           'ext
-           (string-downcase ext-s))]
+     (hash-set* (installer-platform-fields platform-token)
+                'filename s
+                'distribution (if (equal? prefix "racket-textual") 'minimal 'full)
+                'version-token version-token
+                'variant 'bc
+                'ext (string-downcase ext-s))]
     [_ #f]))
 
 ;; -------- HTML parsing --------
 
 (define (parse-legacy-installers-index-html html)
-  (define hrefs
-    (for/list ([m (in-list (regexp-match* #px"href=\"([^\"]+)\"" html #:match-select cdr))])
-      (car m)))
   (remove-duplicates
-   (filter values
-           (for/list ([h (in-list hrefs)])
-             (and (string? h) (regexp-match? #px"^(?:racket|racket-textual)-.+\\.sh$" h) h)))
+   (for/list ([h (in-list (regexp-match* #px"href=\"([^\"]+)\"" html #:match-select cadr))]
+              #:when (regexp-match? #px"^(?:racket|racket-textual)-.+\\.sh$" h))
+     h)
    string=?))
 
 (define (parse-plt-version-page-html html)
   (remove-duplicates
-   (for/list ([m (in-list (regexp-match*
-                           #px"<option[^>]*value=\"(https?://download[.]plt-scheme[.]org/[^\"]+)\""
-                           html
-                           #:match-select cdr))])
-     (car m))
+   (regexp-match* #px"<option[^>]*value=\"(https?://download[.]plt-scheme[.]org/[^\"]+)\""
+                  html
+                  #:match-select cadr)
    string=?))
 
 ;; -------- Installer selection --------
@@ -193,9 +153,6 @@
   (match (regexp-match (pregexp (format "^plt-~a-bin-(.+)-sh[.]html$" (regexp-quote version*))) base)
     [(list _ platform-token) (format "plt-~a-bin-~a.sh" version platform-token)]
     [_ (rackup-error "unexpected PLT Scheme generated page URL: ~a" page-url)]))
-
-(define (version-maybe-plt-scheme? v)
-  (legacy-plt-version? v))
 
 ;; -------- Installer mode detection --------
 

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -151,21 +151,18 @@
   (define idx (load-index))
   (define registered (installed-toolchain-ids idx))
   (define orphan-ids (filter (lambda (id) (not (member id registered))) (toolchain-dir-ids/safe)))
-  (define (unique xs)
-    (and (= (length xs) 1) (car xs)))
-  (define (ambiguous xs)
-    (and (> (length xs) 1)
-         (rackup-error "multiple orphan/partial toolchain directories match '~a': ~a"
-                       spec
-                       (string-join xs ", "))))
+  (define (unique-or-ambiguous xs)
+    (cond
+      [(null? xs) #f]
+      [(null? (cdr xs)) (car xs)]
+      [else
+       (rackup-error "multiple orphan/partial toolchain directories match '~a': ~a"
+                     spec
+                     (string-join xs ", "))]))
+  (define rx (pregexp (format "(^|-)~a([.-]|-|$)" (regexp-quote spec))))
   (or (and (member spec orphan-ids) spec)
-      (let ([xs (filter (lambda (id) (string-prefix? id spec)) orphan-ids)])
-        (or (unique xs) (ambiguous xs)))
-      (let* ([quoted (regexp-quote spec)]
-             [rx (pregexp (format "(^|-)~a([.-]|-|$)" quoted))]
-             [xs (filter (lambda (id) (regexp-match? rx id)) orphan-ids)])
-        (or (unique xs) (ambiguous xs)))
-      #f))
+      (unique-or-ambiguous (filter (lambda (id) (string-prefix? id spec)) orphan-ids))
+      (unique-or-ambiguous (filter (lambda (id) (regexp-match? rx id)) orphan-ids))))
 
 (define (remove-orphan-toolchain! id)
   (define tc-dir (rackup-toolchain-dir id))
@@ -368,8 +365,7 @@
                    (set! toolchain (resolve-toolchain-or-die id))]
                   #:args (exe)
                   exe))
-  (define tc toolchain)
-  (define p (resolve-executable-path exe tc))
+  (define p (resolve-executable-path exe toolchain))
   (if p
       (displayln (path->string p))
       (begin
@@ -829,7 +825,7 @@
   (remove-duplicates
    (filter values
            (for/list ([m (in-list (installed-toolchain-metas/safe))])
-             (and (hash? m) (equal? (hash-ref m 'kind #f) 'local) (hash-ref m 'source-path #f))))
+             (and (equal? (hash-ref m 'kind #f) 'local) (hash-ref m 'source-path #f))))
    string=?))
 
 (define (warn-uninstall-summary home-path)

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -2,6 +2,7 @@
 
 (require racket/cmdline
          racket/file
+         racket/format
          racket/list
          racket/match
          racket/path
@@ -29,6 +30,7 @@
          "checksum.rkt"
          "env.rkt"
          "error.rkt"
+         "fs.rkt"
          "process.rkt"
          "security.rkt"
          "text.rkt"
@@ -52,7 +54,7 @@
 (define-runtime-path rackup-repo-anchor "../../.gitignore")
 
 (define (usage-line cmd desc)
-  (printf "  ~a~a~a\n" cmd (make-string (max 2 (- 22 (string-length cmd))) #\space) desc))
+  (printf "  ~a  ~a\n" (~a cmd #:min-width 20) desc))
 
 (define version-help
   (string-append
@@ -121,7 +123,7 @@
 ;; If spec is a meta-name like "stable", try resolving it to an actual
 ;; version number and look up locally.  Returns the ID or #f.
 (define (try-resolve-meta-spec spec)
-  (with-handlers ([exn:fail? (lambda (_) #f)])
+  (try-or #f
     (define spec* (parse-install-spec spec))
     (match (hash-ref spec* 'kind)
       ['stable
@@ -137,7 +139,7 @@
   id)
 
 (define (toolchain-dir-ids/safe)
-  (with-handlers ([exn:fail? (lambda (_) null)])
+  (try-or null
     (if (directory-exists? (rackup-toolchains-dir))
         (sort (for/list ([p (in-list (directory-list (rackup-toolchains-dir) #:build? #t))]
                          #:when (or (directory-exists? p) (link-exists? p)))
@@ -168,21 +170,14 @@
 (define (remove-orphan-toolchain! id)
   (define tc-dir (rackup-toolchain-dir id))
   (define addon (rackup-addon-dir id))
-  (unless (or (link-exists? tc-dir) (directory-exists? tc-dir))
+  (unless (dir-or-link-exists? tc-dir)
     (rackup-error "orphan toolchain directory not found: ~a" id))
   (delete-toolchain-dir! tc-dir)
   (when (directory-exists? addon)
     (delete-directory/files addon))
-  (with-handlers ([exn:fail? (lambda (_) (void))])
+  (try-or (void)
     (with-state-lock (reshim!)))
   (displayln (format "Removed orphan/partial toolchain directory ~a" id)))
-
-(define (yes?/default-yes s)
-  (define a
-    (if (string? s)
-        (string-downcase (string-trim s))
-        "__no__"))
-  (or (string=? a "") (member a '("y" "yes"))))
 
 ;; Open the controlling terminal for interactive prompts.  A parameter
 ;; so tests can substitute string ports.
@@ -221,7 +216,7 @@
           (fprintf out "Toolchain '~a' is not installed. Install it now? [Y/n] " spec)
           (flush-output out)
           (read-line in))))
-     (unless (yes?/default-yes answer)
+     (unless (yes-answer? answer #:empty-means-yes? #t)
        (rackup-error "toolchain not installed: ~a" spec))
      (install-toolchain! spec '())]))
 
@@ -451,16 +446,9 @@
   (printf "Initialized shell integration in ~a\n" (path->string rc)))
 
 (define (split-on-double-dash xs)
-  (let loop ([left null]
-             [rest xs])
-    (cond
-      [(null? rest) (values (reverse left) null)]
-      [(equal? (car rest) "--") (values (reverse left) (cdr rest))]
-      [else (loop (cons (car rest) left) (cdr rest))])))
-
-(define (toolchain-runtime-env-vars id)
-  (append (toolchain-env-vars id)
-          (list (cons "PLTADDONDIR" (path->string (rackup-addon-dir id))))))
+  (define-values (head tail)
+    (splitf-at xs (lambda (x) (not (equal? x "--")))))
+  (values head (if (pair? tail) (cdr tail) null)))
 
 (define (cmd-run rest)
   (ensure-index!)
@@ -478,7 +466,7 @@
      (define env (environment-variables-copy (current-environment-variables)))
      (restore-saved-racket-env-vars! env)
      (environment-variables-set! env #"RACKUP_TOOLCHAIN" (string->bytes/utf-8 id))
-     (for ([kv (in-list (toolchain-runtime-env-vars id))])
+     (for ([kv (in-list (toolchain-runtime-env id))])
        (define key (string->bytes/utf-8 (car kv)))
        ;; For PLTCOMPILEDROOTS, respect a user-set value restored above.
        (unless (and (equal? (car kv) "PLTCOMPILEDROOTS")
@@ -832,7 +820,7 @@
   yes?)
 
 (define (installed-toolchain-metas/safe)
-  (with-handlers ([exn:fail? (lambda (_) null)])
+  (try-or null
     (filter hash?
             (for/list ([id (in-list (installed-toolchain-ids))])
               (read-toolchain-meta id)))))
@@ -847,7 +835,7 @@
 (define (warn-uninstall-summary home-path)
   (define home-str (path->string home-path))
   (define ids
-    (with-handlers ([exn:fail? (lambda (_) null)])
+    (try-or null
       (installed-toolchain-ids)))
   (define linked-paths (linked-source-paths/safe))
   (eprintf "WARNING: `rackup uninstall` is destructive.\n")
@@ -998,7 +986,7 @@
   (define repo (hash-ref opts 'repo #f))
   (define custom-source? (or ref repo))
   (define source (self-upgrade-script-source #:ref ref #:repo repo))
-(define (parse-sha256-sidecar text)
+  (define (parse-sha256-sidecar text)
     (for/or ([line (in-list (string-split (string-downcase text) "\n"))])
       (match (regexp-match #px"^([0-9a-f]{64})\\b" (string-trim line))
         [(list _ sha) sha]
@@ -1045,13 +1033,12 @@
             (if ref (list "--ref" ref) null)
             (if repo (list "--repo" repo) null)
             (list "--prefix" home-str)))
-  (define env (environment-variables-copy (current-environment-variables)))
-  (environment-variables-set! env #"RACKUP_BOOTSTRAP_MODE" #"self-upgrade")
   (define ok?
-    (parameterize ([current-environment-variables env])
-      (apply system* (shell-exe) script-path args)))
+    (call-with-env-overlay
+     '(("RACKUP_BOOTSTRAP_MODE" . "self-upgrade"))
+     (lambda () (apply system* (shell-exe) script-path args))))
   (when (and (url-like? source) (file-exists? script-path))
-    (with-handlers ([exn:fail? (lambda (_) (void))])
+    (try-or (void)
       (delete-file script-path)))
   (unless ok?
     (rackup-error "self-upgrade failed"))
@@ -1082,7 +1069,7 @@
      (displayln baked-version)]
     [else
      (define (git-output . args)
-       (with-handlers ([exn:fail? (lambda (_) #f)])
+       (try-or #f
          (define out (open-output-string))
          (define git (find-executable-path "git"))
          (and git

--- a/libexec/rackup/paths.rkt
+++ b/libexec/rackup/paths.rkt
@@ -32,8 +32,6 @@
          rackup-runtime-bin-link
          rackup-index-file
          rackup-config-file
-         rackup-legacy-config-file
-         rackup-legacy-shim-aliases-file
          rackup-default-file
          rackup-shim-dispatcher
          rackup-shim-path
@@ -122,8 +120,6 @@
 (define-paths-under (rackup-state-dir)
   [rackup-index-file                "index.rktd"]
   [rackup-config-file               "config"]
-  [rackup-legacy-config-file        "config.rktd"]
-  [rackup-legacy-shim-aliases-file  "shim-aliases"]
   [rackup-default-file              "default-toolchain"])
 
 (define-paths-under (rackup-libexec-dir) [rackup-shim-dispatcher "rackup-shim"])

--- a/libexec/rackup/process.rkt
+++ b/libexec/rackup/process.rkt
@@ -14,11 +14,13 @@
          system*/check
          find-executable-path/default
          shell-exe
+         call-with-env-overlay
          capture-program-output
+         run-quiet-program
          probe-local-racket-version+variant+addon-dir)
 
 (define (executable-file? p)
-  (with-handlers ([exn:fail? (lambda (_) #f)])
+  (try-or #f
     (and (member 'execute (file-or-directory-permissions p)) #t)))
 
 (define (system*/check who . args)
@@ -38,23 +40,42 @@
            v
            (string->bytes/utf-8 (format "~a" v)))))
 
-(define (capture-program-output #:env [env-vars null] exe . args)
+;; Call `thunk` with `env-vars` (an alist; values may be strings,
+;; bytes, or #f to unset) overlaid on a copy of the current
+;; environment, so subprocesses see the overlay but nothing leaks into
+;; the calling process.
+(define (call-with-env-overlay env-vars thunk)
   (define env (environment-variables-copy (current-environment-variables)))
   (for ([kv (in-list env-vars)])
     (environment-variables-set! env
                                 (string->bytes/utf-8 (format "~a" (car kv)))
                                 (->env-bytes (cdr kv))))
-  (define out (open-output-string))
+  (parameterize ([current-environment-variables env])
+    (thunk)))
+
+(define (capture-program-output #:env [env-vars null] exe . args)
+  (call-with-env-overlay
+   env-vars
+   (lambda ()
+     (define out (open-output-string))
+     (parameterize ([current-output-port out]
+                    [current-error-port (open-output-string)])
+       (and (apply system* exe args)
+            (string-trim (get-output-string out)))))))
+
+;; Run a program discarding stdout; returns (values ok? stderr-text)
+;; so the caller can report errors only on failure.
+(define (run-quiet-program exe . args)
   (define err (open-output-string))
-  (parameterize ([current-environment-variables env]
-                 [current-output-port out]
-                 [current-error-port err])
-    (and (apply system* exe args)
-         (string-trim (get-output-string out)))))
+  (define ok?
+    (parameterize ([current-output-port (open-output-nowhere)]
+                   [current-error-port err])
+      (apply system* exe args)))
+  (values ok? (string-trim (get-output-string err))))
 
 (define (string->value s)
   (and (string? s) (not (equal? s ""))
-       (with-handlers ([exn:fail? (lambda (_) #f)])
+       (try-or #f
          (read (open-input-string s)))))
 
 ;; Probe a local Racket binary for its version, variant ("cs"|"bc"), and

--- a/libexec/rackup/rebuild.rkt
+++ b/libexec/rackup/rebuild.rkt
@@ -63,7 +63,7 @@
     [else
      (parameterize ([current-output-port (open-output-string)]
                     [current-error-port (open-output-string)])
-       (with-handlers ([exn:fail? (lambda (_) #f)])
+       (try-or #f
          (system*-proc git "-C" (~a path) "rev-parse" "--is-inside-work-tree")))]))
 
 (define (run-git-pull! source-root system*-proc displayln-proc)

--- a/libexec/rackup/remote.rkt
+++ b/libexec/rackup/remote.rkt
@@ -847,7 +847,7 @@
      ;; pre-release.racket-lang.org may not publish installers/version.rktd.
      ;; Derive a usable version from table.rktd when that metadata is absent.
      (define maybe-version-rktd
-       (with-handlers ([exn:fail? (lambda (_) #f)])
+       (try-or #f
          (fetch-version-rktd pre-release-installers-base)))
      (define resolved-version
        (let ([from-rktd (and maybe-version-rktd

--- a/libexec/rackup/remote.rkt
+++ b/libexec/rackup/remote.rkt
@@ -175,20 +175,18 @@
 ;; (full block) for whole cells, this gives sub-cell granularity.
 (define eighth-blocks
   (vector "" "▏" "▎" "▍" "▌" "▋" "▊" "▉"))
-(define full-block "█")
-(define empty-block "░")
+(define full-block #\█)
+(define empty-block #\░)
 
 (define (progress-bar fraction)
   (define f (max 0.0 (min 1.0 fraction)))
   (define total-eighths (inexact->exact (floor (* f progress-bar-width 8))))
   (define-values (full extra) (quotient/remainder total-eighths 8))
   (define filled
-    (string-append (apply string-append (for/list ([_ (in-range full)]) full-block))
+    (string-append (make-string full full-block)
                    (vector-ref eighth-blocks extra)))
   (define filled-cells (+ full (if (positive? extra) 1 0)))
-  (define empty
-    (apply string-append
-           (for/list ([_ (in-range (- progress-bar-width filled-cells))]) empty-block)))
+  (define empty (make-string (- progress-bar-width filled-cells) empty-block))
   (string-append "[" filled empty "]"))
 
 (define (progress-enabled?)
@@ -359,50 +357,12 @@
 (define (parse-installer-filename s)
   (match (regexp-match installer-rx s)
     [(list _ prefix version-token platform-token variant-s ext)
-     (define variant
-       (if variant-s
-           (string->symbol variant-s)
-           'bc))
-     (define distribution (if (equal? prefix "racket-minimal") 'minimal 'full))
-     (define parts (string-split platform-token "-"))
-     (define arch-token
-       (if (pair? parts)
-           (car parts)
-           platform-token))
-     (define platform-parts
-       (if (>= (length parts) 2)
-           (cdr parts)
-           null))
-     (define platform
-       (if (pair? platform-parts)
-           (string-join platform-parts "-")
-           ""))
-     (define platform-family
-       (if (pair? platform-parts)
-           (car platform-parts)
-           platform))
-     (hash 'filename
-           s
-           'distribution
-           distribution
-           'version-token
-           version-token
-           'platform-token
-           platform-token
-           'arch-token
-           arch-token
-           'arch
-           (arch-token->normalized arch-token)
-           'platform
-           platform
-           'platform-family
-           platform-family
-           'platform-parts
-           platform-parts
-           'variant
-           variant
-           'ext
-           (string-downcase ext))]
+     (hash-set* (installer-platform-fields platform-token)
+                'filename s
+                'distribution (if (equal? prefix "racket-minimal") 'minimal 'full)
+                'version-token version-token
+                'variant (if variant-s (string->symbol variant-s) 'bc)
+                'ext (string-downcase ext))]
     [_ #f]))
 
 (define (table-filenames table)
@@ -457,40 +417,62 @@
                                             #:platform platform
                                             #:ext "sh")))
 
-(define (release-request-hash requested-spec
-                              resolved-version
-                              variant
-                              distribution*
-                              arch
-                              platform
-                              base
-                              filename)
+(define (install-request-hash #:kind kind
+                              #:requested-spec requested-spec
+                              #:resolved-version resolved-version
+                              #:version-token [version-token resolved-version]
+                              #:variant variant
+                              #:distribution distribution
+                              #:arch arch
+                              #:platform platform
+                              #:base base
+                              #:filename filename
+                              #:snapshot-site [snapshot-site #f]
+                              #:snapshot-stamp [snapshot-stamp #f])
   (hash 'kind
-        'release
+        kind
         'requested-spec
         requested-spec
         'resolved-version
         resolved-version
         'version-token
-        resolved-version
+        version-token
         'variant
         variant
         'distribution
-        distribution*
+        distribution
         'arch
         arch
         'platform
         platform
         'snapshot-site
-        #f
+        snapshot-site
         'snapshot-stamp
-        #f
+        snapshot-stamp
         'installers-base
         base
         'installer-filename
         filename
         'installer-url
         (string-append base filename)))
+
+;; Fetch the corresponding download page's checksums and attach the one
+;; for `filename` (SHA-256, or SHA-1 for old releases) to the request.
+(define (attach-page-checksum req base filename)
+  (define checksums (fetch-page-checksums (download-page-url-for-base base)))
+  (match (hash-ref checksums filename #f)
+    [(cons 'sha256 hex) (hash-set req 'installer-sha256 hex)]
+    [(cons 'sha1 hex) (hash-set req 'installer-sha1 hex)]
+    [#f req]))
+
+;; Call (proc distribution); when a 'full request fails, retry with
+;; 'minimal.  Returns (values result actual-distribution).
+(define (try-with-minimal-fallback distribution* proc)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (if (eq? distribution* 'full)
+                                   (values (proc 'minimal) 'minimal)
+                                   (raise e)))])
+    (values (proc distribution*) distribution*)))
 
 (define (exn-message-looks-like-404? e)
   (regexp-match? #px"\\b404\\b" (exn-message e)))
@@ -502,8 +484,20 @@
                                           arch
                                           platform
                                           preferred-exts)
+  (define (release-request resolved-distribution base filename)
+    (attach-page-checksum
+     (install-request-hash #:kind 'release
+                           #:requested-spec requested-spec
+                           #:resolved-version resolved-version
+                           #:variant variant
+                           #:distribution resolved-distribution
+                           #:arch arch
+                           #:platform platform
+                           #:base base
+                           #:filename filename)
+     base filename))
   (cond
-    [(version-maybe-plt-scheme? resolved-version)
+    [(legacy-plt-version? resolved-version)
      (define plt-request
        (legacy-plt-request-info resolved-version
                                 #:distribution distribution*
@@ -513,14 +507,15 @@
      (define url* (hash-ref plt-request 'url))
      (define base* (substring url* 0 (- (string-length url*) (string-length filename*))))
      (hash-set*
-      (release-request-hash requested-spec
-                            resolved-version
-                            variant
-                            distribution*
-                            arch
-                            platform
-                            base*
-                            filename*)
+      (install-request-hash #:kind 'release
+                            #:requested-spec requested-spec
+                            #:resolved-version resolved-version
+                            #:variant variant
+                            #:distribution distribution*
+                            #:arch arch
+                            #:platform platform
+                            #:base base*
+                            #:filename filename*)
       'installer-sha256
       (hash-ref plt-request 'sha256)
       'legacy-install-kind
@@ -535,82 +530,32 @@
          (fetch-table-rktd base)))
      (cond
        [table
-     (define-values (filename actual-distribution)
-       (with-handlers ([exn:fail?
-                        (lambda (e)
-                          (if (eq? distribution* 'full)
-                              (values (select-installer-filename/by-ext table
-                                        #:version-token resolved-version
-                                        #:variant variant
-                                        #:distribution 'minimal
-                                        #:arch arch
-                                        #:platform platform
-                                        #:exts preferred-exts
-                                        #:allow-version-prefix? #t)
-                                      'minimal)
-                              (raise e)))])
-         (values (select-installer-filename/by-ext table
-                                         #:version-token resolved-version
-                                         #:variant variant
-                                         #:distribution distribution*
-                                         #:arch arch
-                                         #:platform platform
-                                         #:exts preferred-exts
-                                         #:allow-version-prefix? #t)
-                 distribution*)))
-     (define page-url (download-page-url-for-base base))
-     (define checksums (fetch-page-checksums page-url))
-     (define cksum (hash-ref checksums filename #f))
-     (define req (release-request-hash requested-spec
-                                       resolved-version
-                                       variant
-                                       actual-distribution
-                                       arch
-                                       platform
-                                       base
-                                       filename))
-     (cond
-       [(and cksum (eq? (car cksum) 'sha256))
-        (hash-set req 'installer-sha256 (cdr cksum))]
-       [(and cksum (eq? (car cksum) 'sha1))
-        (hash-set req 'installer-sha1 (cdr cksum))]
-       [else req])]
+        (define-values (filename actual-distribution)
+          (try-with-minimal-fallback
+           distribution*
+           (lambda (dist)
+             (select-installer-filename/by-ext table
+                                               #:version-token resolved-version
+                                               #:variant variant
+                                               #:distribution dist
+                                               #:arch arch
+                                               #:platform platform
+                                               #:exts preferred-exts
+                                               #:allow-version-prefix? #t))))
+        (release-request actual-distribution base filename)]
        [else
         ;; Older Racket releases may use Apache index listings (e.g. 5.2).
-        (define-values (base* filename* actual-distribution)
-          (with-handlers ([exn:fail?
-                           (lambda (e)
-                             (if (eq? distribution* 'full)
-                                 (let-values ([(b f)
-                                               (fetch-legacy-installer-filename resolved-version
-                                                                                #:distribution 'minimal
-                                                                                #:arch arch
-                                                                                #:platform platform)])
-                                   (values b f 'minimal))
-                                 (raise e)))])
-            (let-values ([(b f)
-                          (fetch-legacy-installer-filename resolved-version
-                                                           #:distribution distribution*
-                                                           #:arch arch
-                                                           #:platform platform)])
-              (values b f distribution*))))
-        (define page-url* (download-page-url-for-base base*))
-        (define checksums* (fetch-page-checksums page-url*))
-        (define cksum* (hash-ref checksums* filename* #f))
-        (define req* (release-request-hash requested-spec
-                                           resolved-version
-                                           variant
-                                           actual-distribution
-                                           arch
-                                           platform
-                                           base*
-                                           filename*))
-        (cond
-          [(and cksum* (eq? (car cksum*) 'sha256))
-           (hash-set req* 'installer-sha256 (cdr cksum*))]
-          [(and cksum* (eq? (car cksum*) 'sha1))
-           (hash-set req* 'installer-sha1 (cdr cksum*))]
-          [else req*])])]))
+        (define-values (base+filename actual-distribution)
+          (try-with-minimal-fallback
+           distribution*
+           (lambda (dist)
+             (let-values ([(b f)
+                           (fetch-legacy-installer-filename resolved-version
+                                                            #:distribution dist
+                                                            #:arch arch
+                                                            #:platform platform)])
+               (cons b f)))))
+        (release-request actual-distribution (car base+filename) (cdr base+filename))])]))
 
 (define (distribution-fallback? actual-distribution requested-distribution)
   (and (eq? actual-distribution 'minimal)
@@ -809,7 +754,7 @@
           ["linux"   '("sh" "tgz")]
           [_ (rackup-error "no installer extension preferences for platform: ~a" platform)])))
   (define (variant-for version)
-    (define legacy-plt? (version-maybe-plt-scheme? version))
+    (define legacy-plt? (legacy-plt-version? version))
     (define v
       (if variant-override
           (parse-variant variant-override)
@@ -888,42 +833,18 @@
                                                distribution*)]
                                       [else (raise e)]))])
          (values (select-pre-release "current") distribution*)))
-     (define pre-page-url (download-page-url-for-base pre-release-installers-base))
-     (define pre-checksums (fetch-page-checksums pre-page-url))
-     (define pre-cksum (hash-ref pre-checksums filename #f))
-     (define pre-req
-       (hash 'kind
-             'pre-release
-             'requested-spec
-             requested-spec
-             'resolved-version
-             resolved-version
-             'version-token
-             "current"
-             'variant
-             variant
-             'distribution
-             actual-distribution
-             'arch
-             arch
-             'platform
-             platform
-             'snapshot-site
-             #f
-             'snapshot-stamp
-             #f
-             'installers-base
-             pre-release-installers-base
-             'installer-filename
-             filename
-             'installer-url
-             (string-append pre-release-installers-base filename)))
-     (cond
-       [(and pre-cksum (eq? (car pre-cksum) 'sha256))
-        (hash-set pre-req 'installer-sha256 (cdr pre-cksum))]
-       [(and pre-cksum (eq? (car pre-cksum) 'sha1))
-        (hash-set pre-req 'installer-sha1 (cdr pre-cksum))]
-       [else pre-req])]
+     (attach-page-checksum
+      (install-request-hash #:kind 'pre-release
+                            #:requested-spec requested-spec
+                            #:resolved-version resolved-version
+                            #:version-token "current"
+                            #:variant variant
+                            #:distribution actual-distribution
+                            #:arch arch
+                            #:platform platform
+                            #:base pre-release-installers-base
+                            #:filename filename)
+      pre-release-installers-base filename)]
     ['snapshot
      (define requested-site
        (normalize-site-option (hash-ref spec* 'snapshot-site #f) snapshot-site-opt))
@@ -937,20 +858,13 @@
            (parse-variant variant-override)
            'cs))
      (define-values (picked actual-distribution)
-       (with-handlers ([exn:fail?
-                        (lambda (e)
-                          (if (eq? distribution* 'full)
-                              (values (try-resolve-snapshot-site sites-to-try
-                                                                 #:distribution 'minimal
-                                                                 #:arch arch
-                                                                 #:variant variant)
-                                      'minimal)
-                              (raise e)))])
-         (values (try-resolve-snapshot-site sites-to-try
-                                            #:distribution distribution*
-                                            #:arch arch
-                                            #:variant variant)
-                 distribution*)))
+       (try-with-minimal-fallback
+        distribution*
+        (lambda (dist)
+          (try-resolve-snapshot-site sites-to-try
+                                     #:distribution dist
+                                     #:arch arch
+                                     #:variant variant))))
      (define site (hash-ref picked 'site))
      (define base (snapshot-installers-base site))
      (define table (hash-ref picked 'table))
@@ -967,42 +881,20 @@
                                            #:arch arch
                                            #:platform platform
                                            #:exts preferred-exts))
-     (define snap-page-url (download-page-url-for-base base))
-     (define snap-checksums (fetch-page-checksums snap-page-url))
-     (define snap-cksum (hash-ref snap-checksums filename #f))
-     (define snap-req
-       (hash 'kind
-             'snapshot
-             'requested-spec
-             requested-spec
-             'resolved-version
-             resolved-version
-             'version-token
-             "current"
-             'variant
-             variant
-             'distribution
-             actual-distribution
-             'arch
-             arch
-             'platform
-             platform
-             'snapshot-site
-             site
-             'snapshot-stamp
-             stamp
-             'installers-base
-             base
-             'installer-filename
-             filename
-             'installer-url
-             (string-append base filename)))
-     (cond
-       [(and snap-cksum (eq? (car snap-cksum) 'sha256))
-        (hash-set snap-req 'installer-sha256 (cdr snap-cksum))]
-       [(and snap-cksum (eq? (car snap-cksum) 'sha1))
-        (hash-set snap-req 'installer-sha1 (cdr snap-cksum))]
-       [else snap-req])]
+     (attach-page-checksum
+      (install-request-hash #:kind 'snapshot
+                            #:requested-spec requested-spec
+                            #:resolved-version resolved-version
+                            #:version-token "current"
+                            #:variant variant
+                            #:distribution actual-distribution
+                            #:arch arch
+                            #:platform platform
+                            #:base base
+                            #:filename filename
+                            #:snapshot-site site
+                            #:snapshot-stamp stamp)
+      base filename)]
     [_ (rackup-error "unsupported install kind: ~a" kind)]))
 
 (module+ for-testing

--- a/libexec/rackup/rktd-io.rkt
+++ b/libexec/rackup/rktd-io.rkt
@@ -34,34 +34,25 @@
         (call-with-input-file* path read-rktd/port))
       default))
 
-(define (call-with-atomic-output-file path writer)
-  (define dir (or (path-only path) (current-directory)))
+;; Atomic write via racket/file's call-with-atomic-output-file
+;; (temp file + rename), additionally preserving the permission bits of
+;; an existing file at `path` — the stdlib temp file starts with
+;; default permissions.
+(define (write-file-atomically path writer)
   (define perms (and (file-exists? path) (file-or-directory-permissions path 'bits)))
-  (make-directory* dir)
-  (define tmp (make-temporary-file "rackup-write-~a" #f dir))
-  (dynamic-wind
-   void
-   (lambda ()
-     (call-with-output-file* tmp
-       #:exists 'truncate/replace
-       (lambda (out)
-         (writer out)
-         (flush-output out)))
-     (when perms
-       (file-or-directory-permissions tmp perms))
-     (rename-file-or-directory tmp path #t))
-   (lambda ()
-     (when (file-exists? tmp)
-       (delete-file tmp)))))
+  (make-directory* (or (path-only path) (current-directory)))
+  (call-with-atomic-output-file path (lambda (out _tmp) (writer out)))
+  (when perms
+    (file-or-directory-permissions path perms)))
 
 (define (write-string-file path s)
-  (call-with-atomic-output-file path
+  (write-file-atomically path
     (lambda (out)
       (display s out)
       (newline out))))
 
 (define (write-rktd-file path v)
-  (call-with-atomic-output-file path
+  (write-file-atomically path
     (lambda (out)
       (write v out)
       (newline out))))

--- a/libexec/rackup/runtime.rkt
+++ b/libexec/rackup/runtime.rkt
@@ -57,7 +57,7 @@
   (define current (rackup-runtime-current-link))
   (cond
     [(link-exists? current)
-     (with-handlers ([exn:fail? (lambda (_) #f)])
+     (try-or #f
        (define target (resolve-path current))
        (and target (path-basename-string target)))]
     [else #f]))
@@ -66,26 +66,8 @@
   (define id (runtime-current-id))
   (and id (read-rktd-file (rackup-runtime-meta-file id) #f)))
 
-(define (runtime-cache-file installer-url)
-  (build-path (rackup-download-cache-dir)
-              (path-basename-string (string->path (car (reverse (string-split installer-url "/")))))))
-
-(define (ensure-installer-cached! installer-url
-                                  #:sha256 [expected-sha256 #f]
-                                  #:sha1 [expected-sha1 #f])
-  (ensure-rackup-layout!)
-  (require-checksummed-http-installer! installer-url expected-sha256)
-  (define cache-path (runtime-cache-file installer-url))
-  (when (and (file-exists? cache-path) (or expected-sha256 expected-sha1))
-    (with-handlers ([exn:fail? (lambda (_) (delete-file cache-path))])
-      (verify-installer-checksum! cache-path #:sha256 expected-sha256 #:sha1 expected-sha1)))
-  (unless (file-exists? cache-path)
-    (displayln (format "Downloading hidden runtime installer: ~a" installer-url))
-    (download-url->file installer-url cache-path)
-    (verify-installer-checksum! cache-path #:sha256 expected-sha256 #:sha1 expected-sha1)
-    (when (regexp-match? #px"[.]sh$" (string-downcase (path->string* cache-path)))
-      (file-or-directory-permissions cache-path #o755)))
-  cache-path)
+(define (announce-runtime-installer-download url)
+  (displayln (format "Downloading hidden runtime installer: ~a" url)))
 
 (define (run-linux-installer! installer-file install-root)
   (define installer (path->complete-path installer-file))
@@ -227,15 +209,6 @@
    string<?
    #:key path->string*))
 
-(define (run-quiet-program exe . args)
-  (define out (open-output-nowhere))
-  (define err (open-output-string))
-  (define ok?
-    (parameterize ([current-output-port out]
-                   [current-error-port err])
-      (apply system* exe args)))
-  (values ok? (string-trim (get-output-string err))))
-
 (define (precompile-rackup-sources!)
   (define racket-exe (hidden-runtime-racket-path))
   (define sources (rackup-source-paths))
@@ -272,7 +245,8 @@
              [installer-file
               (ensure-installer-cached! installer-url
                                         #:sha256 (hash-ref req 'installer-sha256 #f)
-                                        #:sha1 (hash-ref req 'installer-sha1 #f))]
+                                        #:sha1 (hash-ref req 'installer-sha1 #f)
+                                        #:announce announce-runtime-installer-download)]
              [installer-ext (detect-installer-type installer-file)])
         (if (and (directory-exists? version-dir) (file-exists? (build-path bin-link "racket")))
             (begin
@@ -398,5 +372,4 @@
     [_ (rackup-error "usage: rackup runtime status|install|upgrade")]))
 
 (module+ for-testing
-  (provide hidden-runtime-invocation-prefix
-           ensure-installer-cached!))
+  (provide hidden-runtime-invocation-prefix))

--- a/libexec/rackup/shell.rkt
+++ b/libexec/rackup/shell.rkt
@@ -1,4 +1,4 @@
-#lang at-exp racket/base
+#lang racket/base
 
 (require racket/file
          racket/format
@@ -57,15 +57,18 @@
     ["zsh" (write-zsh-completion-script)]))
 
 (define path-prepend
-  @~a{if [ -d "${RACKUP_HOME:-$HOME/.rackup}/shims" ]; then
-        case ":$PATH:" in *":${RACKUP_HOME:-$HOME/.rackup}/shims:"*) ;; *) export PATH="${RACKUP_HOME:-$HOME/.rackup}/shims:$PATH" ;; esac
-      fi@"\n"})
+  (string-append
+   "if [ -d \"${RACKUP_HOME:-$HOME/.rackup}/shims\" ]; then\n"
+   "  case \":$PATH:\" in *\":${RACKUP_HOME:-$HOME/.rackup}/shims:\"*) ;;"
+   " *) export PATH=\"${RACKUP_HOME:-$HOME/.rackup}/shims:$PATH\" ;; esac\n"
+   "fi\n"))
 
 (define (managed-rc-block shell-name)
-  (define shell-script @~a{${RACKUP_HOME:-$HOME/.rackup}/shell/rackup.@|shell-name|})
-  @~a{@|start-marker|
-      [ -f "@|shell-script|" ] && . "@|shell-script|"
-      @|end-marker|@"\n"})
+  (define shell-script
+    (string-append "${RACKUP_HOME:-$HOME/.rackup}/shell/rackup." shell-name))
+  (string-append start-marker "\n"
+                 "[ -f \"" shell-script "\" ] && . \"" shell-script "\"\n"
+                 end-marker "\n"))
 
 (define (emit-shell-activation toolchain-id)
   (unless (toolchain-exists? toolchain-id)
@@ -74,7 +77,8 @@
   ;; (PLTCOMPILEDROOTS, PLTADDONDIR, PLTHOME) are set internally by the
   ;; shim dispatcher via env.sh, scoped to each invocation — not exported
   ;; into the user's shell where they would leak into non-rackup commands.
-  @~a{@|path-prepend|export RACKUP_TOOLCHAIN=@(sh-single-quote toolchain-id)@"\n"})
+  (string-append path-prepend
+                 "export RACKUP_TOOLCHAIN=" (sh-single-quote toolchain-id) "\n"))
 
 (define (deactivation-extra-vars)
   (define active (getenv "RACKUP_TOOLCHAIN"))
@@ -90,10 +94,12 @@
     (apply string-append
            (for/list ([k (in-list (deactivation-extra-vars))])
              (~a "unset " k "\n"))))
-  @~a{@|path-prepend|@|extras|unset RACKUP_TOOLCHAIN
-      unset PLTADDONDIR
-      unset PLTCOMPILEDROOTS
-      unset PLTHOME@"\n"})
+  (string-append path-prepend
+                 extras
+                 "unset RACKUP_TOOLCHAIN\n"
+                 "unset PLTADDONDIR\n"
+                 "unset PLTCOMPILEDROOTS\n"
+                 "unset PLTHOME\n"))
 
 (define (guess-shell)
   (if (regexp-match? #px"/zsh$" (or (getenv "SHELL") "")) "zsh" "bash"))

--- a/libexec/rackup/shims.rkt
+++ b/libexec/rackup/shims.rkt
@@ -25,7 +25,9 @@
          shim-aliases-installed?
          install-shim-aliases!
          remove-shim-aliases!
-         reprobe-local-toolchain)
+         reprobe-local-toolchain
+         write-toolchain-env-file!
+         sync-toolchain-env-file!)
 
 (define bootstrap-shim-names
   '("racket" "raco"))
@@ -350,7 +352,7 @@ EOF
 (define/state-locked (remove-shim-aliases!)
   (clear-config-flag! "short-aliases"))
 
-(define (write-env-file! id env-vars)
+(define (write-toolchain-env-file! id env-vars)
   (define p (rackup-toolchain-env-file id))
   (define body
     (string-append "#!/usr/bin/env bash\n"
@@ -360,16 +362,18 @@ EOF
                             (env-var-export-line (car kv) (cdr kv))))))
   (define existing
     (and (file-exists? p)
-         (with-handlers ([exn:fail? (lambda (_) #f)])
+         (try-or #f
            (file->string p))))
   (unless (equal? existing body)
     (write-string-file p body)
     (file-or-directory-permissions p #o644)))
 
-(define (delete-env-file! id)
-  (define p (rackup-toolchain-env-file id))
-  (when (file-exists? p)
-    (delete-file p)))
+;; Write env.sh when there are env vars to record, delete it otherwise
+;; (an empty env file is never left behind).
+(define (sync-toolchain-env-file! id env-vars)
+  (if (pair? env-vars)
+      (write-toolchain-env-file! id env-vars)
+      (delete-path! (rackup-toolchain-env-file id))))
 
 ;; Re-probe a linked toolchain's racket binary.  Returns (values
 ;; version variant addon-dir), all #f if the binary is missing or
@@ -409,10 +413,6 @@ EOF
   (define addon-dir
     (or probed-addon
         (lookup-env-var (hash-ref meta 'env-vars '()) "PLTADDONDIR")))
-  (define addon-entry
-    (if (and (string? addon-dir) (not (string-blank? addon-dir)))
-        (list (cons "PLTADDONDIR" addon-dir))
-        null))
   (define existing-roots
     (if real-bin-dir-str
         (read-toolchain-compiled-file-roots (string->path real-bin-dir-str))
@@ -420,13 +420,7 @@ EOF
   (define local-name
     (and (eq? (hash-ref meta 'kind #f) 'local)
          (hash-ref meta 'requested-spec #f)))
-  (define compiled-roots-entry
-    (cond
-      [(compiled-roots-value version variant existing-roots local-name)
-       =>
-       (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
-      [else null]))
-  (values (append addon-entry compiled-roots-entry)
+  (values (toolchain-env-var-entries addon-dir version variant existing-roots local-name)
           version
           variant))
 
@@ -445,11 +439,9 @@ EOF
     (define new-env-vars
       (append current (list (cons "PLTCOMPILEDROOTS" computed-pcr))))
     (define new-meta
-      (hash-set meta 'env-vars
-                (for/list ([kv (in-list new-env-vars)])
-                  (list (car kv) (cdr kv)))))
+      (hash-set meta 'env-vars (env-vars->meta new-env-vars)))
     (write-toolchain-meta! id new-meta)
-    (write-env-file! id new-env-vars)))
+    (write-toolchain-env-file! id new-env-vars)))
 
 (define (regenerate-env-files!)
   (for ([id (in-list (installed-toolchain-ids))])
@@ -464,9 +456,7 @@ EOF
            (compute-local-env-vars meta))
          (define updates
            (filter values
-                   (list (cons 'env-vars
-                               (for/list ([kv (in-list env-vars)])
-                                 (list (car kv) (cdr kv))))
+                   (list (cons 'env-vars (env-vars->meta env-vars))
                          (and new-version (cons 'resolved-version new-version))
                          (and new-variant (cons 'variant new-variant)))))
          (define new-meta
@@ -474,9 +464,7 @@ EOF
              (hash-set m (car u) (cdr u))))
          (unless (equal? new-meta meta)
            (write-toolchain-meta! id new-meta))
-         (if (pair? env-vars)
-             (write-env-file! id env-vars)
-             (delete-env-file! id))]
+         (sync-toolchain-env-file! id env-vars)]
         [else
          (backfill-installed-env-vars! id meta)]))))
 

--- a/libexec/rackup/state.rkt
+++ b/libexec/rackup/state.rkt
@@ -42,7 +42,7 @@
          clear-config-flag!)
 
 (define (empty-index)
-  (hash 'installed-toolchains (hash) 'aliases (hash) 'default-toolchain #f))
+  (hash 'installed-toolchains (hash) 'default-toolchain #f))
 
 (define (normalize-index idx)
   (cond
@@ -50,10 +50,6 @@
      (hash 'installed-toolchains
            (if (hash? (hash-ref idx 'installed-toolchains #f))
                (hash-ref idx 'installed-toolchains)
-               (hash))
-           'aliases
-           (if (hash? (hash-ref idx 'aliases #f))
-               (hash-ref idx 'aliases)
                (hash))
            'default-toolchain
            (hash-ref idx 'default-toolchain #f))]
@@ -69,16 +65,6 @@
   (ensure-rackup-layout!)
   (unless (file-exists? (rackup-index-file))
     (save-index! (empty-index)))
-  ;; Migrate old config.rktd to plain text config if needed
-  (define old-config (rackup-legacy-config-file))
-  (when (and (file-exists? old-config) (not (file-exists? (rackup-config-file))))
-    (write-string-file (rackup-config-file) "")
-    (delete-file old-config))
-  ;; Migrate old shim-aliases marker to config flag
-  (define old-aliases (rackup-legacy-shim-aliases-file))
-  (when (file-exists? old-aliases)
-    (set-config-flag! "short-aliases")
-    (delete-file old-aliases))
   (unless (file-exists? (rackup-config-file))
     (write-string-file (rackup-config-file) ""))
   (load-index))
@@ -119,15 +105,11 @@
 
 (define (meta->env-vars m)
   (define raw (and (hash? m) (hash-ref m 'env-vars #f)))
-  (cond
-    [(hash? raw)
-     (for/list ([k (in-list (sort (hash-keys raw) string<?))])
-       (cons k (hash-ref raw k)))]
-    [(list? raw)
-     (for/list ([entry (in-list raw)]
-                #:when (and (list? entry) (= (length entry) 2)))
-       (cons (format "~a" (car entry)) (format "~a" (cadr entry))))]
-    [else null]))
+  (if (list? raw)
+      (for/list ([entry (in-list raw)]
+                 #:when (and (list? entry) (= (length entry) 2)))
+        (cons (format "~a" (car entry)) (format "~a" (cadr entry))))
+      null))
 
 (define (toolchain-env-vars id)
   (meta->env-vars (read-toolchain-meta id)))
@@ -332,7 +314,7 @@
 ;; Returns the matching toolchain ID or #f.
 ;; When #:error-on-ambiguous? is #t, raises an error listing the
 ;; matches instead of returning #f for ambiguous names.
-(define (resolve-name-with-meta name ids aliases all-meta
+(define (resolve-name-with-meta name ids all-meta
                                 #:error-on-ambiguous? [error-on-ambiguous? #f])
   (define (unique xs) (and (= (length xs) 1) (car xs)))
   ;; When multiple toolchains match, prefer "full" distribution over others.
@@ -352,7 +334,6 @@
                     name
                     (string-join xs "\n  ")))))))
   (cond
-    [(hash-has-key? aliases name) (hash-ref aliases name)]
     [(member name ids) name]
     [else
      (or (unique (filter (lambda (id) (string-prefix? id name)) ids))
@@ -369,12 +350,11 @@
     [(or (not name) (string-blank? name)) (get-default-toolchain idx)]
     [else
      (define ids (installed-toolchain-ids idx))
-     (define aliases (hash-ref idx 'aliases (hash)))
      (define all-meta
        (for/list ([id ids])
          (cons id (read-toolchain-meta id))))
-     (resolve-name-with-meta name ids aliases all-meta
-                              #:error-on-ambiguous? #t)]))
+     (resolve-name-with-meta name ids all-meta
+                             #:error-on-ambiguous? #t)]))
 
 ;; Return the short names that uniquely resolve to this toolchain.
 ;; Accepts optional #:all-meta to avoid redundant file reads when
@@ -387,13 +367,8 @@
           (cons tid (read-toolchain-meta tid)))))
   (define m (cdr (assoc id all-meta)))
   (define candidates (toolchain-meta-names m))
-  (define aliases (hash-ref idx 'aliases (hash)))
-  (define alias-names
-    (for/list ([(k v) (in-hash aliases)]
-               #:when (equal? v id))
-      k))
-  (filter (lambda (name) (equal? id (resolve-name-with-meta name ids aliases all-meta)))
-          (remove-duplicates (append alias-names candidates))))
+  (filter (lambda (name) (equal? id (resolve-name-with-meta name ids all-meta)))
+          (remove-duplicates candidates)))
 
 ;; Determine whether a toolchain's metadata indicates it is
 ;; channel-based (upgradeable).  The kind field is 'release for both
@@ -424,19 +399,19 @@
            ["snapshot" "snapshot"]
            [(regexp #px"^snapshot:") "snapshot"]
            [_ "unknown"])))
-  (for/list ([id (in-list ids)]
-             #:when (let ([m (read-toolchain-meta id)])
-                      (and (upgradeable-meta? m)
-                           (or (not filter-channel)
-                               (let ([spec (hash-ref m 'requested-spec #f)])
-                                 (cond
-                                   [(equal? filter-channel "snapshot")
-                                    (and (string? spec)
-                                         (or (equal? spec "snapshot")
-                                             (string-prefix? spec "snapshot:")))]
-                                   [else
-                                    (equal? spec filter-channel)]))))))
-    (cons id (read-toolchain-meta id))))
+  (for*/list ([id (in-list ids)]
+              [m (in-value (read-toolchain-meta id))]
+              #:when (and (upgradeable-meta? m)
+                          (or (not filter-channel)
+                              (let ([spec (hash-ref m 'requested-spec #f)])
+                                (cond
+                                  [(equal? filter-channel "snapshot")
+                                   (and (string? spec)
+                                        (or (equal? spec "snapshot")
+                                            (string-prefix? spec "snapshot:")))]
+                                  [else
+                                   (equal? spec filter-channel)])))))
+    (cons id m)))
 
 (define (ensure-toolchain-addon-dir! id)
   (ensure-directory* (rackup-addon-dir id)))

--- a/libexec/rackup/state.rkt
+++ b/libexec/rackup/state.rkt
@@ -25,7 +25,10 @@
          read-toolchain-meta
          write-toolchain-meta!
          toolchain-env-vars
+         toolchain-runtime-env
          meta->env-vars
+         env-vars->meta
+         toolchain-env-var-entries
          compiled-roots-value
          read-toolchain-compiled-file-roots
          register-toolchain!
@@ -103,8 +106,7 @@
   (save-index! (hash-set idx 'default-toolchain id)))
 
 (define/state-locked (clear-default-toolchain!)
-  (when (file-exists? (rackup-default-file))
-    (delete-file (rackup-default-file)))
+  (delete-path! (rackup-default-file))
   (when (file-exists? (rackup-index-file))
     (define idx (load-index))
     (save-index! (hash-set idx 'default-toolchain #f))))
@@ -130,6 +132,18 @@
 (define (toolchain-env-vars id)
   (meta->env-vars (read-toolchain-meta id)))
 
+;; The inverse of meta->env-vars: serialize an env-var alist into the
+;; list-of-two-element-lists form stored under 'env-vars in meta.rktd.
+(define (env-vars->meta env-vars)
+  (for/list ([kv (in-list env-vars)])
+    (list (car kv) (cdr kv))))
+
+;; Environment for running a toolchain's own executables (raco/racket):
+;; the toolchain's recorded env vars plus its rackup-managed addon dir.
+(define (toolchain-runtime-env id)
+  (append (toolchain-env-vars id)
+          (list (cons "PLTADDONDIR" (path->string (rackup-addon-dir id))))))
+
 ;; Read the compiled-file-roots from a toolchain's config.rktd.
 ;; Returns a list like (same) or ("/usr/lib/racket/compiled"), or
 ;; (same) as default if the file is missing or has no entry.
@@ -148,7 +162,7 @@
   (define config
     (for/or ([p (in-list candidates)])
       (and (file-exists? p)
-           (with-handlers ([exn:fail? (lambda (_) #f)])
+           (try-or #f
              (call-with-input-file p read)))))
   (cond
     [(and (hash? config) (list? (hash-ref config 'compiled-file-roots #f)))
@@ -209,6 +223,21 @@
      (define fallbacks (map serialize-compiled-root roots-with-same))
      (string-join (cons key fallbacks) ":")]
     [else #f]))
+
+;; Build the env-var alist recorded for a toolchain: PLTADDONDIR (when
+;; a usable addon dir is known) and PLTCOMPILEDROOTS (when the
+;; version+variant yield a stable key).  Entries are omitted when
+;; unavailable.
+(define (toolchain-env-var-entries addon-dir version variant existing-roots local-name)
+  (append
+   (if (and (string? addon-dir) (not (string-blank? addon-dir)))
+       (list (cons "PLTADDONDIR" addon-dir))
+       null)
+   (cond
+     [(compiled-roots-value version variant existing-roots local-name)
+      =>
+      (lambda (v) (list (cons "PLTCOMPILEDROOTS" v)))]
+     [else null])))
 
 (define (meta-summary meta)
   (for/hash ([k '(id kind

--- a/libexec/rackup/templates/bash-completion.scrbl
+++ b/libexec/rackup/templates/bash-completion.scrbl
@@ -1,14 +1,6 @@
 
 # rackup bash completion
-_rackup_toolchains() {
-  local dir="${RACKUP_HOME:-$HOME/.rackup}/toolchains"
-  if [ -d "$dir" ]; then
-    local f
-    for f in "$dir"/*/; do
-      [ -d "$f" ] && basename "$f"
-    done
-  fi
-}
+@include/text["toolchains-fn.scrbl"]
 
 _rackup() {
   local cur prev words cword

--- a/libexec/rackup/templates/toolchains-fn.scrbl
+++ b/libexec/rackup/templates/toolchains-fn.scrbl
@@ -1,0 +1,9 @@
+_rackup_toolchains() {
+  local dir="${RACKUP_HOME:-$HOME/.rackup}/toolchains"
+  if [ -d "$dir" ]; then
+    local f
+    for f in "$dir"/*/; do
+      [ -d "$f" ] && basename "$f"
+    done
+  fi
+}

--- a/libexec/rackup/templates/zsh-completion.scrbl
+++ b/libexec/rackup/templates/zsh-completion.scrbl
@@ -1,14 +1,6 @@
 
 # rackup zsh completion
-_rackup_toolchains() {
-  local dir="${RACKUP_HOME:-$HOME/.rackup}/toolchains"
-  if [ -d "$dir" ]; then
-    local f
-    for f in "$dir"/*/; do
-      [ -d "$f" ] && basename "$f"
-    done
-  fi
-}
+@include/text["toolchains-fn.scrbl"]
 
 # Emit toolchain id:description pairs for zsh _describe.
 _rackup_toolchains_described() {

--- a/libexec/rackup/text.rkt
+++ b/libexec/rackup/text.rkt
@@ -10,6 +10,7 @@
          path-basename-string
          sh-single-quote
          env-var-export-line
+         yes-answer?
          color-enabled?
          ansi)
 
@@ -35,6 +36,16 @@
 
 (define (env-var-export-line key value)
   (format "export ~a=~a\n" key (sh-single-quote value)))
+
+;; Interpret an interactive yes/no answer.  Non-strings (#f, eof) count
+;; as no answer.  `#:empty-means-yes?` selects the default for a bare
+;; enter: #t for a "[Y/n]" prompt, #f for a "[y/N]" prompt.
+(define (yes-answer? s #:empty-means-yes? [empty-yes? #f])
+  (define a (and (string? s) (string-downcase (string-trim s))))
+  (cond
+    [(not a) #f]
+    [(string=? a "") empty-yes?]
+    [else (and (member a '("y" "yes")) #t)]))
 
 (define (color-enabled?)
   (and (terminal-port? (current-output-port)) (not (getenv "NO_COLOR"))))

--- a/libexec/rackup/versioning.rkt
+++ b/libexec/rackup/versioning.rkt
@@ -17,6 +17,7 @@
          normalized-host-arch
          host-platform-token
          arch-token->normalized
+         installer-platform-fields
          variant->string
          distribution->string)
 
@@ -31,25 +32,11 @@
      (match (regexp-match #px"^([0-9]+(?:\\.[0-9]+){0,3})(?:p([0-9]+))?$" v)
        [(list _ base patch-s)
         (define patch (if patch-s (string->number patch-s) 0))
-        (match (string-split base ".")
-          [(list a b c d)
-           (+ (* (string->number a) (expt 10 10))
-              (* (string->number b) (expt 10 7))
-              (* (string->number c) (expt 10 4))
-              (* (string->number d) 10)
-              patch)]
-          [(list a b c)
-           (+ (* (string->number a) (expt 10 10))
-              (* (string->number b) (expt 10 7))
-              (* (string->number c) (expt 10 4))
-              patch)]
-          [(list a b)
-           (+ (* (string->number a) (expt 10 10))
-              (* (string->number b) (expt 10 7))
-              patch)]
-          [(list a)
-           (+ (* (string->number a) (expt 10 10)) patch)]
-          [_ 0])]
+        ;; Pad to a.b.c.d; absent components count as 0.
+        (define parts (map string->number (string-split base ".")))
+        (match-define (list a b c d)
+          (append parts (make-list (- 4 (length parts)) 0)))
+        (+ (* a (expt 10 10)) (* b (expt 10 7)) (* c (expt 10 4)) (* d 10) patch)]
        [_ 0])]))
 
 (define (cmp-versions a b)
@@ -152,19 +139,23 @@
     [(unix)   "linux"]
     [else (rackup-error "unsupported platform: ~a" (system-type 'os))]))
 
+;; Decompose an installer filename's platform token (e.g.
+;; "x86_64-linux-ubuntu") into the arch/platform fields shared by the
+;; modern (remote.rkt) and legacy (legacy.rkt) filename parsers.
+(define (installer-platform-fields platform-token)
+  (define parts (string-split platform-token "-"))
+  (define arch-token (if (pair? parts) (car parts) platform-token))
+  (define platform-parts (if (pair? parts) (cdr parts) null))
+  (define platform (string-join platform-parts "-"))
+  (hash 'platform-token platform-token
+        'arch-token arch-token
+        'arch (arch-token->normalized arch-token)
+        'platform platform
+        'platform-family (if (pair? platform-parts) (car platform-parts) platform)
+        'platform-parts platform-parts))
+
 (define (arch-token->normalized token)
-  (cond
-    [(equal? token "x86_64") "x86_64"]
-    [(equal? token "aarch64") "aarch64"]
-    [(equal? token "arm64") "aarch64"]
-    [(equal? token "i386") "i386"]
-    [(equal? token "arm") "arm"]
-    [(equal? token "riscv64") "riscv64"]
-    [(or (equal? token "ppc")
-         (equal? token "powerpc")
-         (equal? token "ppc64")
-         (equal? token "ppc64le")
-         (equal? token "powerpc64")
-         (equal? token "powerpc64le"))
-     "ppc"]
+  (case token
+    [("arm64") "aarch64"]
+    [("powerpc" "ppc64" "ppc64le" "powerpc64" "powerpc64le") "ppc"]
     [else token]))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -280,6 +280,17 @@ download_file() {
   fi
 }
 
+# Download a URL and print its contents to stdout.
+download_stdout() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" 2>/dev/null
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$1" 2>/dev/null
+  else
+    return 1
+  fi
+}
+
 # Like download_file, but show a progress bar on stderr when stderr is a
 # terminal.  Use for large downloads (binary tarballs) where the user
 # benefits from seeing progress.
@@ -375,6 +386,60 @@ has_prebuilt_binary() {
   esac
 }
 
+# Extract a .tar.gz into DEST_DIR and print the single top-level
+# directory it contains (empty output if there is none).
+# Use -m so future mtimes in the archive do not produce noisy warnings
+# on skewed clocks.
+extract_tarball_dir() {
+  tarball="$1"
+  dest_dir="$2"
+  mkdir -p "$dest_dir"
+  tar -xzmf "$tarball" -C "$dest_dir"
+  find "$dest_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1
+}
+
+# Install an unpacked prebuilt binary distribution (bin/, lib/, libexec/)
+# from $1 into $PREFIX, handling macOS quarantine and code signing.
+# The caller must have verified that $1/bin/rackup-core is executable.
+install_binary_distribution() {
+  binary_dir="$1"
+  mkdir -p "$PREFIX/bin" "$PREFIX/libexec"
+  cp "$binary_dir/bin/rackup" "$PREFIX/bin/rackup"
+  cp "$binary_dir/bin/rackup-core" "$PREFIX/bin/rackup-core"
+  chmod +x "$PREFIX/bin/rackup" "$PREFIX/bin/rackup-core"
+  # Remove macOS quarantine flag so Gatekeeper does not kill the binary.
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -dr com.apple.quarantine "$PREFIX/bin" 2>/dev/null || true
+  fi
+  # Ad-hoc sign on macOS so the binary passes code signature
+  # validation.  macOS 26 (Tahoe) can reject signatures produced
+  # by older macOS versions' codesign tool (see
+  # https://github.com/astral-sh/uv/pull/17123).  Re-signing with
+  # the user's local codesign ensures the signature is accepted.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    if command -v codesign >/dev/null 2>&1; then
+      codesign --sign - --force "$PREFIX/bin/rackup-core" || {
+        warn "Error: codesign failed on $PREFIX/bin/rackup-core"
+        warn "The binary may be killed by the kernel on macOS 26+."
+      }
+    else
+      warn "Warning: codesign not found; cannot re-sign binary."
+      warn "Install Xcode Command Line Tools: xcode-select --install"
+      warn "Otherwise the binary may be killed on macOS 26+."
+    fi
+  fi
+  if [ -d "$binary_dir/lib" ]; then
+    rm -rf "${PREFIX:?}/lib"
+    cp -R "$binary_dir/lib" "$PREFIX/lib"
+    if command -v xattr >/dev/null 2>&1; then
+      xattr -dr com.apple.quarantine "$PREFIX/lib" 2>/dev/null || true
+    fi
+  fi
+  cp "$binary_dir/libexec/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"
+  chmod +x "$PREFIX/libexec/rackup-bootstrap.sh"
+  INSTALLED_PREBUILT=1
+}
+
 # --- Early up-to-date check for self-upgrade ---
 # On self-upgrade from the default repo, download just the tiny checksum
 # file and compare to the stored hash.  Skip the full install if they match.
@@ -383,34 +448,20 @@ if [ "$BOOTSTRAP_MODE" = "self-upgrade" ] && [ -z "$FROM_LOCAL" ] &&
   [ "$REF" = "main" ]; then
   _upgrade_base_url="${PAGES_BASE_URL:-https://samth.github.io/rackup}"
   _installed_sha_file="$PREFIX/.installed-sha256"
-  if [ "$FORCE_SOURCE" -eq 1 ]; then
-    _remote_sha_url="$_upgrade_base_url/rackup-src.tar.gz.sha256"
-  elif [ "$FORCE_EXE" -eq 1 ]; then
-    _host_arch="$(detect_arch)"
-    _host_platform="$(detect_platform)"
-    _host_binary_target="$(binary_target "$_host_arch" "$_host_platform")"
+  _host_arch="$(detect_arch)"
+  _host_platform="$(detect_platform)"
+  _host_binary_target="$(binary_target "$_host_arch" "$_host_platform")"
+  # In auto mode, check the exe checksum if a prebuilt is available, source otherwise.
+  if [ "$FORCE_SOURCE" -eq 0 ] &&
+    { [ "$FORCE_EXE" -eq 1 ] || has_prebuilt_binary "${_host_arch}-${_host_platform}"; }; then
     _remote_sha_url="$_upgrade_base_url/rackup-${_host_binary_target}.tar.gz.sha256"
   else
-    # Auto mode: check the exe checksum if a prebuilt is available, source otherwise.
-    _host_arch="$(detect_arch)"
-    _host_platform="$(detect_platform)"
-    _host_binary_target="$(binary_target "$_host_arch" "$_host_platform")"
-    if has_prebuilt_binary "${_host_arch}-${_host_platform}"; then
-      _remote_sha_url="$_upgrade_base_url/rackup-${_host_binary_target}.tar.gz.sha256"
-    else
-      _remote_sha_url="$_upgrade_base_url/rackup-src.tar.gz.sha256"
-    fi
+    _remote_sha_url="$_upgrade_base_url/rackup-src.tar.gz.sha256"
   fi
   if [ -f "$_installed_sha_file" ]; then
     _installed_sha="$(cat "$_installed_sha_file")"
     _remote_sha=""
-    if command -v curl >/dev/null 2>&1; then
-      _remote_sha_content="$(curl -fsSL "$_remote_sha_url" 2>/dev/null)" || true
-    elif command -v wget >/dev/null 2>&1; then
-      _remote_sha_content="$(wget -qO- "$_remote_sha_url" 2>/dev/null)" || true
-    else
-      _remote_sha_content=""
-    fi
+    _remote_sha_content="$(download_stdout "$_remote_sha_url")" || _remote_sha_content=""
     if [ -n "$_remote_sha_content" ]; then
       _remote_sha="$(echo "$_remote_sha_content" | cut -d ' ' -f 1)"
     fi
@@ -420,6 +471,16 @@ if [ "$BOOTSTRAP_MODE" = "self-upgrade" ] && [ -z "$FROM_LOCAL" ] &&
     fi
   fi
 fi
+
+# Rebuild shims, then record the installed checksum ($1, may be empty)
+# only after reshim succeeds, so a failed upgrade can be retried (the
+# self-upgrade up-to-date check compares this hash).
+reshim_and_store_checksum() {
+  "$PREFIX/bin/rackup" reshim >/dev/null
+  if [ -n "$1" ]; then
+    printf '%s\n' "$1" >"$PREFIX/.installed-sha256"
+  fi
+}
 
 # --- Try prebuilt binary before falling back to source ---
 INSTALLED_PREBUILT=0
@@ -469,29 +530,10 @@ if [ -z "$FROM_LOCAL" ] && [ "$FORCE_SOURCE" -eq 0 ]; then
         GH_TARBALL="$GH_TMPDIR/$BINARY_NAME"
         if [ -f "$GH_TARBALL" ]; then
           info "Downloaded CI binary artifact for $BINARY_TARGET."
-          mkdir -p "$TMPDIR_INSTALL/binary"
-          tar -xzmf "$GH_TARBALL" -C "$TMPDIR_INSTALL/binary"
-          BINARY_DIR="$(find "$TMPDIR_INSTALL/binary" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+          BINARY_DIR="$(extract_tarball_dir "$GH_TARBALL" "$TMPDIR_INSTALL/binary")"
           if [ -n "$BINARY_DIR" ] && [ -x "$BINARY_DIR/bin/rackup-core" ]; then
-            mkdir -p "$PREFIX"
-            mkdir -p "$PREFIX/bin" "$PREFIX/libexec"
-            cp "$BINARY_DIR/bin/rackup" "$PREFIX/bin/rackup"
-            cp "$BINARY_DIR/bin/rackup-core" "$PREFIX/bin/rackup-core"
-            chmod +x "$PREFIX/bin/rackup" "$PREFIX/bin/rackup-core"
-            if command -v xattr >/dev/null 2>&1; then
-              xattr -dr com.apple.quarantine "$PREFIX/bin" 2>/dev/null || true
-            fi
-            if [ -d "$BINARY_DIR/lib" ]; then
-              rm -rf "${PREFIX:?}/lib"
-              cp -R "$BINARY_DIR/lib" "$PREFIX/lib"
-              if command -v xattr >/dev/null 2>&1; then
-                xattr -dr com.apple.quarantine "$PREFIX/lib" 2>/dev/null || true
-              fi
-            fi
-            cp "$BINARY_DIR/libexec/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"
-            chmod +x "$PREFIX/libexec/rackup-bootstrap.sh"
+            install_binary_distribution "$BINARY_DIR"
             ok "Installed prebuilt binary from CI (run $GH_RUN_ID): $PREFIX/bin/rackup"
-            INSTALLED_PREBUILT=1
             GH_BINARY_DOWNLOADED=1
           else
             warn "CI binary artifact was invalid; will try other methods."
@@ -541,48 +583,10 @@ if [ -z "$FROM_LOCAL" ] && [ "$FORCE_SOURCE" -eq 0 ]; then
         rm -f "$TMPDIR_INSTALL/rackup-binary.tar.gz"
       fi
       if [ -f "$TMPDIR_INSTALL/rackup-binary.tar.gz" ]; then
-        mkdir -p "$TMPDIR_INSTALL/binary"
-        tar -xzmf "$TMPDIR_INSTALL/rackup-binary.tar.gz" -C "$TMPDIR_INSTALL/binary"
-        BINARY_DIR="$(find "$TMPDIR_INSTALL/binary" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+        BINARY_DIR="$(extract_tarball_dir "$TMPDIR_INSTALL/rackup-binary.tar.gz" "$TMPDIR_INSTALL/binary")"
         if [ -n "$BINARY_DIR" ] && [ -x "$BINARY_DIR/bin/rackup-core" ]; then
-          mkdir -p "$PREFIX"
-          mkdir -p "$PREFIX/bin" "$PREFIX/libexec"
-          # Install the prebuilt binary distribution
-          cp "$BINARY_DIR/bin/rackup" "$PREFIX/bin/rackup"
-          cp "$BINARY_DIR/bin/rackup-core" "$PREFIX/bin/rackup-core"
-          chmod +x "$PREFIX/bin/rackup" "$PREFIX/bin/rackup-core"
-          # Remove macOS quarantine flag so Gatekeeper does not kill the binary.
-          if command -v xattr >/dev/null 2>&1; then
-            xattr -dr com.apple.quarantine "$PREFIX/bin" 2>/dev/null || true
-          fi
-          # Ad-hoc sign on macOS so the binary passes code signature
-          # validation.  macOS 26 (Tahoe) can reject signatures produced
-          # by older macOS versions' codesign tool (see
-          # https://github.com/astral-sh/uv/pull/17123).  Re-signing with
-          # the user's local codesign ensures the signature is accepted.
-          if [ "$(uname -s)" = "Darwin" ]; then
-            if command -v codesign >/dev/null 2>&1; then
-              codesign --sign - --force "$PREFIX/bin/rackup-core" || {
-                warn "Error: codesign failed on $PREFIX/bin/rackup-core"
-                warn "The binary may be killed by the kernel on macOS 26+."
-              }
-            else
-              warn "Warning: codesign not found; cannot re-sign binary."
-              warn "Install Xcode Command Line Tools: xcode-select --install"
-              warn "Otherwise the binary may be killed on macOS 26+."
-            fi
-          fi
-          if [ -d "$BINARY_DIR/lib" ]; then
-            rm -rf "${PREFIX:?}/lib"
-            cp -R "$BINARY_DIR/lib" "$PREFIX/lib"
-            if command -v xattr >/dev/null 2>&1; then
-              xattr -dr com.apple.quarantine "$PREFIX/lib" 2>/dev/null || true
-            fi
-          fi
-          cp "$BINARY_DIR/libexec/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"
-          chmod +x "$PREFIX/libexec/rackup-bootstrap.sh"
+          install_binary_distribution "$BINARY_DIR"
           ok "Installed prebuilt binary: $PREFIX/bin/rackup"
-          INSTALLED_PREBUILT=1
           INSTALLED_PREBUILT_SHA256="${expected_bin_sha256:-}"
         else
           if [ "$FORCE_EXE" -eq 1 ]; then
@@ -636,10 +640,7 @@ if [ "$INSTALLED_PREBUILT" -eq 0 ]; then
       warn "This is expected when running the repo copy directly. Use --from-local or --archive-url instead."
       exit 1
     fi
-    mkdir -p "$TMPDIR_INSTALL/src"
-    # Use -m so future mtimes in the archive do not produce noisy warnings on skewed clocks.
-    tar -xzmf "$TMPDIR_INSTALL/rackup.tar.gz" -C "$TMPDIR_INSTALL/src"
-    SRC_DIR="$(find "$TMPDIR_INSTALL/src" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+    SRC_DIR="$(extract_tarball_dir "$TMPDIR_INSTALL/rackup.tar.gz" "$TMPDIR_INSTALL/src")"
   fi
 
   if [ -z "$SRC_DIR" ] || [ ! -d "$SRC_DIR" ]; then
@@ -651,21 +652,14 @@ if [ "$INSTALLED_PREBUILT" -eq 0 ]; then
   mkdir -p "$PREFIX/bin" "$PREFIX/libexec"
 
   info "Installing rackup into $PREFIX"
-  copy_filtered_tree() {
-    src_dir="$1"
-    dest_dir="$2"
-    shift 2
-    mkdir -p "$dest_dir"
-    (
-      cd "$src_dir"
-      find "$@" \
-        \( -type d \( -name .git -o -name compiled \) -prune \) -o \
-        \( -type f \( -name '*.zo' -o -name '*.dep' \) -prune \) -o \
-        \( -type f -o -type l \) -print0
-    ) | tar -C "$src_dir" --null -T - -cf - | tar -C "$dest_dir" -xf -
-  }
-
-  copy_filtered_tree "$SRC_DIR" "$PREFIX" bin libexec
+  # The source tarball bundles scripts/copy-filtered-tree.sh for exactly
+  # this step (see pages/build-pages-site.rkt); repo checkouts and
+  # GitHub ref archives contain it too.
+  if [ ! -r "$SRC_DIR/scripts/copy-filtered-tree.sh" ]; then
+    warn "Error: source tree is missing scripts/copy-filtered-tree.sh."
+    exit 1
+  fi
+  sh "$SRC_DIR/scripts/copy-filtered-tree.sh" "$SRC_DIR" "$PREFIX" bin libexec
   chmod +x "$PREFIX/bin/rackup"
   chmod +x "$PREFIX/libexec/rackup-bootstrap.sh" 2>/dev/null || true
 
@@ -702,12 +696,7 @@ if [ "$INSTALLED_PREBUILT" -eq 0 ]; then
 
   info "Registering/validating hidden runtime..."
   "$PREFIX/bin/rackup" runtime install >/dev/null
-  "$PREFIX/bin/rackup" reshim >/dev/null
-  # Store the checksum only after reshim succeeds, so a failed upgrade
-  # can be retried (the up-to-date check compares this hash).
-  if [ -n "${_INSTALLED_SRC_SHA256:-}" ]; then
-    printf '%s\n' "$_INSTALLED_SRC_SHA256" >"$PREFIX/.installed-sha256"
-  fi
+  reshim_and_store_checksum "${_INSTALLED_SRC_SHA256:-}"
 
 fi
 # --- End source/prebuilt branch ---
@@ -725,11 +714,7 @@ if [ "$INSTALLED_PREBUILT" -eq 1 ]; then
   if [ -f "$PREFIX/libexec/rackup-core.rkt" ]; then
     rm -rf "$PREFIX/libexec/rackup" "$PREFIX/libexec/rackup-core.rkt"
   fi
-  "$PREFIX/bin/rackup" reshim >/dev/null
-  # Store the checksum only after reshim succeeds.
-  if [ -n "${INSTALLED_PREBUILT_SHA256:-}" ]; then
-    printf '%s\n' "$INSTALLED_PREBUILT_SHA256" >"$PREFIX/.installed-sha256"
-  fi
+  reshim_and_store_checksum "${INSTALLED_PREBUILT_SHA256:-}"
 fi
 
 default_shell="$(basename "${SHELL:-bash}")"

--- a/test/all.rkt
+++ b/test/all.rkt
@@ -1,24 +1,25 @@
 #lang racket/base
 
-(require rackunit/text-ui
-         "checksum.rkt"
-         "copy-filtered-tree.rkt"
-         "env.rkt"
-         "install-prefix.rkt"
-         "paths.rkt"
-         "process.rkt"
-         "rebuild.rkt"
-         "remote.rkt"
-         "rktd-io.rkt"
-         "security.rkt"
-         "shell-completion.rkt"
-         "state-shims.rkt"
-         "switch-install.rkt"
-         "text.rkt"
-         "uninstall.rkt"
-         "upgrade.rkt"
-         "version.rkt"
-         "versioning.rkt")
+;; Require the `test` submodules explicitly: requiring just the main
+;; modules would skip everything wrapped in (module+ test ...).
+(require (submod "checksum.rkt" test)
+         (submod "copy-filtered-tree.rkt" test)
+         (submod "env.rkt" test)
+         (submod "install-prefix.rkt" test)
+         (submod "paths.rkt" test)
+         (submod "process.rkt" test)
+         (submod "rebuild.rkt" test)
+         (submod "remote.rkt" test)
+         (submod "rktd-io.rkt" test)
+         (submod "security.rkt" test)
+         (submod "shell-completion.rkt" test)
+         (submod "state-shims.rkt" test)
+         (submod "switch-install.rkt" test)
+         (submod "text.rkt" test)
+         (submod "uninstall.rkt" test)
+         (submod "upgrade.rkt" test)
+         (submod "version.rkt" test)
+         (submod "versioning.rkt" test))
 
 (module+ main
   (void))

--- a/test/paths.rkt
+++ b/test/paths.rkt
@@ -28,8 +28,6 @@
                    (build-path tmp "runtime" "current" "bin"))
      (check-equal? (rackup-runtime-current-racket)
                    (build-path tmp "runtime" "current" "bin" "racket"))
-     (check-equal? (rackup-legacy-config-file) (build-path tmp "state" "config.rktd"))
-     (check-equal? (rackup-legacy-shim-aliases-file) (build-path tmp "state" "shim-aliases"))
      (check-equal? (rackup-shim-path "racket") (build-path tmp "shims" "racket"))
      (check-equal? (rackup-toolchain-exe-path "stable" "racket")
                    (build-path tmp "toolchains" "stable" "bin" "racket")))))

--- a/test/remote.rkt
+++ b/test/remote.rkt
@@ -8,14 +8,11 @@
          racket/runtime-path
          racket/string
          "../libexec/rackup/install.rkt"
+         "../libexec/rackup/installer-backend.rkt"
          "../libexec/rackup/legacy-plt-catalog.rkt"
          "../libexec/rackup/remote.rkt"
          "../libexec/rackup/runtime.rkt"
-         (submod "../libexec/rackup/remote.rkt" for-testing)
-         (rename-in (submod "../libexec/rackup/install.rkt" for-testing)
-                    [ensure-installer-cached! install-ensure-installer-cached!])
-         (rename-in (submod "../libexec/rackup/runtime.rkt" for-testing)
-                    [ensure-installer-cached! runtime-ensure-installer-cached!]))
+         (submod "../libexec/rackup/remote.rkt" for-testing))
 
 (module+ test
   (define-runtime-path repo-root "..")
@@ -339,14 +336,7 @@
      (check-exn
       #px"refusing to download installer over HTTP without a hardcoded SHA-256 checksum"
       (lambda ()
-        (install-ensure-installer-cached! "http://download.plt-scheme.org/example.sh")))))
-
-  (with-temp-rackup-home
-   (lambda (_tmp-home)
-     (check-exn
-      #px"refusing to download installer over HTTP without a hardcoded SHA-256 checksum"
-      (lambda ()
-        (runtime-ensure-installer-cached! "http://download.plt-scheme.org/example.sh")))))
+        (ensure-installer-cached! "http://download.plt-scheme.org/example.sh")))))
 
   (check-exn exn:fail?
              (lambda () (resolve-install-request "053" #:arch "i386" #:platform "linux")))

--- a/test/rktd-io.rkt
+++ b/test/rktd-io.rkt
@@ -23,7 +23,8 @@
   (define compiled-payload
     (with-output-to-string
       (lambda ()
-        (write (compile '(+ 1 2))))))
+        (parameterize ([current-namespace (make-base-namespace)])
+          (write (compile '(+ 1 2)))))))
   (check-exn exn:fail? (lambda () (read-rktd/port (open-input-string compiled-payload))))
 
   (define good-rktd (make-temp-file-in-tmp "rackup-rktd-good-~a"))

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -1722,13 +1722,15 @@
   (with-temp-rackup-home
    (lambda (tmp)
      (ensure-rackup-layout!)
-     ;; Write a minimal old-format index that lacks the 'aliases key
+     ;; Write an old-format index with an extra key (the retired
+     ;; 'aliases map); load-index should normalize it without error
      (write-rktd-file (rackup-index-file)
-                      (hash 'installed-toolchains (hash) 'default-toolchain #f))
-     ;; load-index should normalize it without error
+                      (hash 'installed-toolchains (hash)
+                            'aliases (hash)
+                            'default-toolchain #f))
      (define idx (load-index))
      (check-true (hash? idx))
-     (check-equal? (hash-ref idx 'aliases) (hash))
+     (check-false (hash-has-key? idx 'aliases))
      (check-equal? (installed-toolchain-ids idx) null)
 
      ;; Write an even more minimal index (just a hash with installed-toolchains)
@@ -1736,7 +1738,6 @@
                       (hash 'installed-toolchains (hash)))
      (define idx2 (load-index))
      (check-true (hash? idx2))
-     (check-equal? (hash-ref idx2 'aliases) (hash))
      (check-equal? (hash-ref idx2 'default-toolchain) #f)
 
      ;; ensure-index! on top of existing state should preserve it

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -27,7 +27,7 @@
          "../libexec/rackup/versioning.rkt"
          (only-in (submod "../libexec/rackup/install.rkt" for-testing)
                   discover-bin-dir installed-toolchain-env-vars
-                  write-toolchain-env-file! clean-toolchain-compiled-dirs!)
+                  clean-toolchain-compiled-dirs!)
          (only-in (submod "../libexec/rackup/runtime.rkt" for-testing)
                   hidden-runtime-invocation-prefix)
          (submod "../libexec/rackup/shell.rkt" for-testing))
@@ -82,7 +82,30 @@
       fi
       @|fallthrough|})
 
+;; Write an executable fake script for tests.
+(define (write-fake-exe! path body)
+  (write-string-file path body)
+  (file-or-directory-permissions path #o755))
 
+;; Standard toolchain metadata for tests: a release/cs/full toolchain
+;; for x86_64-linux.  Override or extend via key/value pairs, e.g.
+;; (test-toolchain-meta id #:spec "9.0" #:version "9.0" 'variant 'bc).
+(define (test-toolchain-meta id
+                             #:spec [spec "stable"]
+                             #:version [version "9.1"]
+                             . extras)
+  (apply hash-set*
+         (hash 'id id
+               'kind 'release
+               'requested-spec spec
+               'resolved-version version
+               'variant 'cs
+               'distribution 'full
+               'arch "x86_64"
+               'platform "linux"
+               'executables '("racket")
+               'installed-at "2026-02-26T00:00:00Z")
+         extras))
 
 (module+ test
   (with-temp-rackup-home
@@ -116,23 +139,15 @@
      (define install-root (rackup-toolchain-install-dir id))
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
-     (write-string-file (build-path real-bin "racket")
-                        "#!/usr/bin/env bash\nexit 23\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket")
+                      "#!/usr/bin/env bash\nexit 23\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain!
         id
-        (hash 'id id
-              'kind 'release
-              'requested-spec "stable"
-              'resolved-version "8.18"
-              'variant 'cs
-              'distribution 'full
-              'arch "x86_64"
-              'platform "linux"
-              'executables '("racket")
-              'installed-at "2026-02-28T00:00:00Z"))
+        (test-toolchain-meta id
+                             #:version "8.18"
+                             'installed-at "2026-02-28T00:00:00Z"))
        (set-default-toolchain! id)
        (reshim!))
      (expect/shell (list (path->string (build-path (rackup-shims-dir) "racket")) "--version")
@@ -149,18 +164,16 @@
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
      ;; Create a script that prints the path it was invoked as ($0)
-     (write-string-file (build-path real-bin "racket")
-                        "#!/usr/bin/env bash\necho \"$0\"\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket")
+                      "#!/usr/bin/env bash\necho \"$0\"\n")
      ;; Create a launcher script like macOS bin/drracket: resolves symlinks
      ;; on the file but uses `pwd` (not `pwd -P`) for the directory.
      ;; This mimics Racket's make-mred-launcher output.
      (define app-dir (build-path install-root "DrRacket.app"))
      (make-directory* app-dir)
-     (write-string-file (build-path app-dir "DrRacket")
-                        "#!/usr/bin/env bash\necho ok\n")
-     (file-or-directory-permissions (build-path app-dir "DrRacket") #o755)
-     (write-string-file
+     (write-fake-exe! (build-path app-dir "DrRacket")
+                      "#!/usr/bin/env bash\necho ok\n")
+     (write-fake-exe!
       (build-path real-bin "drracket")
       (string-append "#!/bin/sh\n"
                      "# Mimics Racket's make-mred-launcher script.\n"
@@ -172,22 +185,14 @@
                      "cd \"$saveD\"\n"
                      "bindir=\"$D/..\"\n"
                      "exec \"${bindir}/DrRacket.app/DrRacket\" ${1+\"$@\"}\n"))
-     (file-or-directory-permissions (build-path real-bin "drracket") #o755)
      ;; bin is a symlink to install/bin — this is the normal rackup layout
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain!
         id
-        (hash 'id id
-              'kind 'release
-              'requested-spec "stable"
-              'resolved-version "9.1"
-              'variant 'cs
-              'distribution 'full
-              'arch "x86_64"
-              'platform "linux"
-              'executables '("racket" "drracket")
-              'installed-at "2026-03-10T00:00:00Z"))
+        (test-toolchain-meta id
+                             'executables '("racket" "drracket")
+                             'installed-at "2026-03-10T00:00:00Z"))
        (set-default-toolchain! id)
        (reshim!))
      ;; Test 1: racket shim invokes through the resolved path
@@ -229,45 +234,20 @@
                            (define real-bin (build-path install-root "bin"))
                            (make-directory* real-bin)
                            (define racket-exe (build-path real-bin "racket"))
-                           (write-string-file racket-exe "#!/usr/bin/env bash\necho test\n")
-                           (file-or-directory-permissions racket-exe #o755)
+                           (write-fake-exe! racket-exe "#!/usr/bin/env bash\necho test\n")
                            (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
 
                            (define meta
-                             (hash 'id
-                                   id
-                                   'kind
-                                   'release
-                                   'requested-spec
-                                   "stable"
-                                   'resolved-version
-                                   "8.18"
-                                   'variant
-                                   'cs
-                                   'distribution
-                                   'full
-                                   'arch
-                                   "x86_64"
-                                   'platform
-                                   "linux"
-                                   'snapshot-site
-                                   #f
-                                   'snapshot-stamp
-                                   #f
-                                   'installer-url
-                                   "https://example.invalid/racket.sh"
-                                   'installer-filename
-                                   "racket.sh"
-                                   'install-root
-                                   (path->string install-root)
-                                   'bin-link
-                                   (path->string (rackup-toolchain-bin-link id))
-                                   'real-bin-dir
-                                   (path->string real-bin)
-                                   'executables
-                                   '("racket")
-                                   'installed-at
-                                   "2026-02-26T00:00:00Z"))
+                             (test-toolchain-meta
+                              id
+                              #:version "8.18"
+                              'snapshot-site #f
+                              'snapshot-stamp #f
+                              'installer-url "https://example.invalid/racket.sh"
+                              'installer-filename "racket.sh"
+                              'install-root (path->string install-root)
+                              'bin-link (path->string (rackup-toolchain-bin-link id))
+                              'real-bin-dir (path->string real-bin)))
                            (with-state-lock (register-toolchain! id meta))
                            (check-equal? (get-default-toolchain) id)
                            (check-equal? (find-local-toolchain "release-8.18") id)
@@ -369,13 +349,12 @@
      (make-directory* (rackup-toolchain-dir id))
      (make-directory* real-bin)
      (define mzscheme-exe (build-path real-bin "mzscheme"))
-     (write-string-file
+     (write-fake-exe!
       mzscheme-exe
       @~a{#!/usr/bin/env bash
           set -euo pipefail
           printf 'PLTHOME=%s\n' "${PLTHOME:-}"
           })
-     (file-or-directory-permissions mzscheme-exe #o755)
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      ;; Old PLT Scheme (parent dir named "plt") needs PLTHOME for its
      ;; bin/mzscheme shell wrapper to find .bin/<archsys>/mzscheme.
@@ -386,43 +365,24 @@
                                        "export PLTHOME="
                                        (format "'~a'\n" (path->string plthome))))
      (define meta
-       (hash 'id
-             id
-             'kind
-             'release
-             'requested-spec
-             "103"
-             'resolved-version
-             "103"
-             'variant
-             'bc
-             'distribution
-             'full
-             'arch
-             "i386"
-             'platform
-             "linux"
-             'snapshot-site
-             #f
-             'snapshot-stamp
-             #f
-             'installer-url
-             "http://download.plt-scheme.org/bundles/103/plt/plt-103-bin-i386-linux.tgz"
-             'installer-filename
-             "plt-103-bin-i386-linux.tgz"
-             'install-root
-             (path->string install-root)
-             'bin-link
-             (path->string (rackup-toolchain-bin-link id))
-             'real-bin-dir
-             (path->string real-bin)
-             'env-vars
-             (for/list ([kv (in-list env-vars)])
-               (list (car kv) (cdr kv)))
-             'executables
-             '("mzscheme")
-             'installed-at
-             "2026-02-27T00:00:00Z"))
+       (test-toolchain-meta
+        id
+        #:spec "103"
+        #:version "103"
+        'variant 'bc
+        'arch "i386"
+        'snapshot-site #f
+        'snapshot-stamp #f
+        'installer-url
+        "http://download.plt-scheme.org/bundles/103/plt/plt-103-bin-i386-linux.tgz"
+        'installer-filename "plt-103-bin-i386-linux.tgz"
+        'install-root (path->string install-root)
+        'bin-link (path->string (rackup-toolchain-bin-link id))
+        'real-bin-dir (path->string real-bin)
+        'env-vars (for/list ([kv (in-list env-vars)])
+                    (list (car kv) (cdr kv)))
+        'executables '("mzscheme")
+        'installed-at "2026-02-27T00:00:00Z"))
      (with-state-lock
        (register-toolchain! id meta)
        (reshim!))
@@ -448,10 +408,8 @@
      (make-directory* legacy-bin)
      (make-directory* fake-binfmt-dir)
      (define racket-exe (build-path real-bin "racket"))
-     (write-string-file racket-exe "#!/usr/bin/env bash\nexit 139\n")
-     (file-or-directory-permissions racket-exe #o755)
-     (write-string-file archsys "#!/bin/sh\necho i386-linux\n")
-     (file-or-directory-permissions archsys #o755)
+     (write-fake-exe! racket-exe "#!/usr/bin/env bash\nexit 139\n")
+     (write-fake-exe! archsys "#!/bin/sh\necho i386-linux\n")
      (call-with-output-file (build-path legacy-bin "racket")
        (lambda (out)
          (write-bytes #"\177ELF\1" out)
@@ -464,19 +422,15 @@
      (with-state-lock
        (register-toolchain!
         id
-        (hash 'id id
-              'kind 'release
-              'requested-spec "103p1"
-              'resolved-version "103p1"
-              'variant 'bc
-              'distribution 'full
-              'arch "i386"
-              'platform "linux"
-              'install-root (path->string install-root)
-              'bin-link (path->string (rackup-toolchain-bin-link id))
-              'real-bin-dir (path->string real-bin)
-              'executables '("racket")
-              'installed-at "2026-02-28T00:00:00Z"))
+        (test-toolchain-meta id
+                             #:spec "103p1"
+                             #:version "103p1"
+                             'variant 'bc
+                             'arch "i386"
+                             'install-root (path->string install-root)
+                             'bin-link (path->string (rackup-toolchain-bin-link id))
+                             'real-bin-dir (path->string real-bin)
+                             'installed-at "2026-02-28T00:00:00Z"))
        (set-default-toolchain! id)
        (reshim!))
      (define old-binfmt-dir (getenv "RACKUP_TEST_BINFMT_MISC_DIR"))
@@ -514,10 +468,9 @@
      (define real-bin (build-path tmp "plt" "bin"))
      (make-directory* real-bin)
      (define archsys (build-path real-bin "archsys"))
-     (write-string-file
+     (write-fake-exe!
       archsys
       "#!/bin/sh\nif [ `file /bin/ls | grep ELF | wc -l` = 1 ]; then\n  SYS=i386-linux\nelse\n  SYS=i386-linux-aout\nfi\n")
-     (file-or-directory-permissions archsys #o755)
      (maybe-modernize-legacy-archsys! real-bin)
      (define patched (file->string archsys))
      (check-true (string-contains? patched "file -L /bin/ls 2>/dev/null | grep ELF | wc -l"))
@@ -548,8 +501,7 @@
 
      (define (write-exe name body)
        (define p (build-path bin-dir name))
-       (write-string-file p body)
-       (file-or-directory-permissions p #o755)
+       (write-fake-exe! p body)
        p)
 
      (write-exe "racket"
@@ -568,12 +520,11 @@
                     })
      (for ([name '("scheme" "petite")])
        (define p (build-path chez-bin-dir name))
-       (write-string-file p
-                          @~a{#!/usr/bin/env bash
-                              set -euo pipefail
-                              printf '@|name|-ok %s\n' "$*"
-                              })
-       (file-or-directory-permissions p #o755))
+       (write-fake-exe! p
+                        @~a{#!/usr/bin/env bash
+                            set -euo pipefail
+                            printf '@|name|-ok %s\n' "$*"
+                            }))
 
      (define linked-id (link-toolchain! "devsrc" (path->string src-root) '("--set-default")))
      (check-equal? linked-id "local-devsrc")
@@ -743,8 +694,7 @@
 
      (define (write-bin-exe name body)
        (define p (build-path bin-dir name))
-       (write-string-file p body)
-       (file-or-directory-permissions p #o755)
+       (write-fake-exe! p body)
        p)
 
      (write-bin-exe "racket"
@@ -819,12 +769,11 @@
      (make-file-or-directory-link runtime-version-dir (rackup-runtime-current-link))
      (define racket-bin (build-path bin-dir "racket"))
      (define fake-addon-dir (path->string (build-path tmp "fake-addon")))
-     (write-string-file racket-bin
-                        (fake-racket-script
-                         #:version "9.90"
-                         #:addon-dir fake-addon-dir
-                         #:fallthrough "printf 'linked-toolchain-racket\\n'"))
-     (file-or-directory-permissions racket-bin #o755)
+     (write-fake-exe! racket-bin
+                      (fake-racket-script
+                       #:version "9.90"
+                       #:addon-dir fake-addon-dir
+                       #:fallthrough "printf 'linked-toolchain-racket\\n'"))
      (define linked-id (link-toolchain! "devsrc-wrapper" (path->string src-root) '("--set-default")))
      (define poisoned-collects (build-path tmp "poisoned-collects"))
      (make-directory* (build-path poisoned-collects "racket"))
@@ -864,8 +813,7 @@
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
      (define racket-exe (build-path real-bin "racket"))
-     (write-string-file racket-exe "#!/usr/bin/env bash\necho hidden-runtime-test\n")
-     (file-or-directory-permissions racket-exe #o755)
+     (write-fake-exe! racket-exe "#!/usr/bin/env bash\necho hidden-runtime-test\n")
      (make-file-or-directory-link real-bin (rackup-runtime-bin-link runtime-id))
      (make-file-or-directory-link version-dir (rackup-runtime-current-link))
      (write-rktd-file (rackup-runtime-meta-file runtime-id)
@@ -935,14 +883,13 @@
      (define captured-argv (build-path tmp "captured-hidden-runtime-argv.txt"))
      (make-directory* fake-bin-dir)
      (define fake-racket (build-path fake-bin-dir "racket"))
-     (write-string-file fake-racket
-                        (string-append
-                         "#!/usr/bin/env bash\n"
-                         "set -euo pipefail\n"
-                         "printf '%s\\n' \"$@\" > "
-                         (path->string captured-argv)
-                         "\n"))
-     (file-or-directory-permissions fake-racket #o755)
+     (write-fake-exe! fake-racket
+                      (string-append
+                       "#!/usr/bin/env bash\n"
+                       "set -euo pipefail\n"
+                       "printf '%s\\n' \"$@\" > "
+                       (path->string captured-argv)
+                       "\n"))
      (make-directory* version-dir)
      (make-file-or-directory-link fake-bin-dir (rackup-runtime-bin-link runtime-id))
      (make-file-or-directory-link version-dir (rackup-runtime-current-link))
@@ -964,20 +911,19 @@
      (define captured-env (build-path tmp "captured-system-runtime-env.txt"))
      (make-directory* fake-bin-dir)
      (define fake-racket (build-path fake-bin-dir "racket"))
-     (write-string-file fake-racket
-                        (string-append
-                         "#!/usr/bin/env bash\n"
-                         "set -euo pipefail\n"
-                         "printf '%s\\n' \"$@\" > "
-                         (path->string captured-argv)
-                         "\n"
-                         "printf 'PLTHOME=%s\\nPLTCOLLECTS=%s\\nPLTADDONDIR=%s\\n' "
-                         "\"${PLTHOME:-}\" "
-                         "\"${PLTCOLLECTS:-}\" "
-                         "\"${PLTADDONDIR:-}\" > "
-                         (path->string captured-env)
-                         "\n"))
-     (file-or-directory-permissions fake-racket #o755)
+     (write-fake-exe! fake-racket
+                      (string-append
+                       "#!/usr/bin/env bash\n"
+                       "set -euo pipefail\n"
+                       "printf '%s\\n' \"$@\" > "
+                       (path->string captured-argv)
+                       "\n"
+                       "printf 'PLTHOME=%s\\nPLTCOLLECTS=%s\\nPLTADDONDIR=%s\\n' "
+                       "\"${PLTHOME:-}\" "
+                       "\"${PLTCOLLECTS:-}\" "
+                       "\"${PLTADDONDIR:-}\" > "
+                       (path->string captured-env)
+                       "\n"))
      (define env (environment-variables-copy (current-environment-variables)))
      (environment-variables-set! env
                                  #"PATH"
@@ -1034,7 +980,7 @@
    (lambda (tmp)
      (define installer (build-path tmp "racket-textual-5.2-bin-x86_64-linux-fake.sh"))
      (define dest (build-path tmp "legacy-install"))
-     (write-string-file
+     (write-fake-exe!
       installer
       @~a{#!/bin/sh
           set -eu
@@ -1054,7 +1000,6 @@
           chmod +x "$where/bin/racket"
           exit 0
           })
-     (file-or-directory-permissions installer #o755)
      (run-linux-installer! installer dest)
      (check-true (directory-exists? (build-path dest "bin")))
      (check-true (directory-exists? (build-path dest "collects")))
@@ -1064,7 +1009,7 @@
    (lambda (tmp)
      (define installer (build-path tmp "racket-6.0-x86_64-linux-fake.sh"))
      (define dest (build-path tmp "legacy-6.0-install"))
-     (write-string-file
+     (write-fake-exe!
       installer
       @~a{#!/bin/sh
           set -eu
@@ -1092,7 +1037,6 @@
           chmod +x "$where/bin/racket"
           exit 0
           })
-     (file-or-directory-permissions installer #o755)
      (run-linux-installer! installer dest)
      (check-true (directory-exists? (build-path dest "bin")))
      (check-true (directory-exists? (build-path dest "collects")))
@@ -1102,7 +1046,7 @@
    (lambda (tmp)
      (define installer (build-path tmp "racket-6.1.1-x86_64-linux-fake.sh"))
      (define dest (build-path tmp "modern-6.1.1-install"))
-     (write-string-file
+     (write-fake-exe!
       installer
       @~a{#!/bin/sh
           set -eu
@@ -1124,7 +1068,6 @@
           chmod +x "$where/bin/racket"
           exit 0
           })
-     (file-or-directory-permissions installer #o755)
      (run-linux-installer! installer dest)
      (check-true (directory-exists? (build-path dest "bin")))
      (check-true (directory-exists? (build-path dest "collects")))
@@ -1134,7 +1077,7 @@
    (lambda (tmp)
      (define installer (build-path tmp "plt-209-bin-i386-linux-fake.sh"))
      (define dest (build-path tmp "legacy-basic-install"))
-     (write-string-file
+     (write-fake-exe!
       installer
       @~a{#!/bin/sh
           set -eu
@@ -1153,7 +1096,6 @@
           chmod +x "$where/bin/mzscheme"
           exit 0
           })
-     (file-or-directory-permissions installer #o755)
      (run-linux-installer! installer dest #:legacy-install-kind 'shell-basic)
      (check-true (directory-exists? (build-path dest "bin")))
      (check-true (directory-exists? (build-path dest "collects")))
@@ -1163,14 +1105,13 @@
    (lambda (tmp)
      (define installer (build-path tmp "plt-209-bin-i386-linux-fail.sh"))
      (define dest (build-path tmp "legacy-fail-install"))
-     (write-string-file
+     (write-fake-exe!
       installer
       @~a{#!/bin/sh
           set -eu
           echo 'bad 100% format %s output' >&2
           exit 9
           })
-     (file-or-directory-permissions installer #o755)
      (define msg
        (with-handlers ([exn:fail? exn-message])
          (run-linux-installer! installer dest #:legacy-install-kind 'shell-basic)
@@ -1187,9 +1128,8 @@
      (define archive (build-path tmp "racket-minimal-9.1-riscv64-linux-cs.tgz"))
      (define dest (build-path tmp "tgz-install"))
      (make-directory* (build-path archive-root "racket" "bin"))
-     (write-string-file (build-path archive-root "racket" "bin" "racket")
-                        "#!/usr/bin/env bash\necho tgz-runtime\n")
-     (file-or-directory-permissions (build-path archive-root "racket" "bin" "racket") #o755)
+     (write-fake-exe! (build-path archive-root "racket" "bin" "racket")
+                      "#!/usr/bin/env bash\necho tgz-runtime\n")
      (check-true (system* tar-exe "-czf" archive "-C" archive-root "."))
      (extract-tgz-installer! archive dest)
      (check-true (directory-exists? (build-path dest "racket" "bin")))
@@ -1289,45 +1229,21 @@
      (define install-root (rackup-toolchain-install-dir id))
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
-     (write-string-file (build-path real-bin "racket") "#!/usr/bin/env bash\nexit 0\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket") "#!/usr/bin/env bash\nexit 0\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (make-directory* tc-dir)
      (define meta
-       (hash 'id
-             id
-             'kind
-             'release
-             'requested-spec
-             "8.18"
-             'resolved-version
-             "8.18"
-             'variant
-             'cs
-             'distribution
-             'full
-             'arch
-             "x86_64"
-             'platform
-             "linux"
-             'snapshot-site
-             #f
-             'snapshot-stamp
-             #f
-             'installer-url
-             "https://example.invalid/racket.sh"
-             'installer-filename
-             "racket.sh"
-             'install-root
-             (path->string install-root)
-             'bin-link
-             (path->string (rackup-toolchain-bin-link id))
-             'real-bin-dir
-             (path->string real-bin)
-             'executables
-             '("racket")
-             'installed-at
-             "2026-02-26T00:00:00Z"))
+       (test-toolchain-meta
+        id
+        #:spec "8.18"
+        #:version "8.18"
+        'snapshot-site #f
+        'snapshot-stamp #f
+        'installer-url "https://example.invalid/racket.sh"
+        'installer-filename "racket.sh"
+        'install-root (path->string install-root)
+        'bin-link (path->string (rackup-toolchain-bin-link id))
+        'real-bin-dir (path->string real-bin)))
      (with-state-lock (register-toolchain! id meta))
      (expect (run-main '("current" "id")) (format "~a\n" id))
      @expect[(run-main '("current" "source"))]{default
@@ -1380,46 +1296,21 @@
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
      (define racket-exe (build-path real-bin "racket"))
-     (write-string-file racket-exe "#!/usr/bin/env bash\necho test\n")
-     (file-or-directory-permissions racket-exe #o755)
+     (write-fake-exe! racket-exe "#!/usr/bin/env bash\necho test\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain!
         id
-        (hash 'id
-              id
-              'kind
-              'release
-              'requested-spec
-              "stable"
-              'resolved-version
-              "8.18"
-              'variant
-              'cs
-              'distribution
-              'full
-              'arch
-              "x86_64"
-              'platform
-              "linux"
-              'snapshot-site
-              #f
-              'snapshot-stamp
-              #f
-              'installer-url
-              "https://example.invalid/racket.sh"
-              'installer-filename
-              "racket.sh"
-              'install-root
-              (path->string install-root)
-              'bin-link
-              (path->string (rackup-toolchain-bin-link id))
-              'real-bin-dir
-              (path->string real-bin)
-              'executables
-              '("racket")
-              'installed-at
-              "2026-02-26T00:00:00Z"))
+        (test-toolchain-meta
+         id
+         #:version "8.18"
+         'snapshot-site #f
+         'snapshot-stamp #f
+         'installer-url "https://example.invalid/racket.sh"
+         'installer-filename "racket.sh"
+         'install-root (path->string install-root)
+         'bin-link (path->string (rackup-toolchain-bin-link id))
+         'real-bin-dir (path->string real-bin)))
        (reshim!))
      (define old-env-id (getenv "RACKUP_TOOLCHAIN"))
      (dynamic-wind
@@ -1467,13 +1358,12 @@
      (define fake-installer (build-path tmp "fake-install.sh"))
      (define args-log (build-path tmp "self-upgrade-args.log"))
      (define mode-log (build-path tmp "self-upgrade-mode.log"))
-     (write-string-file
+     (write-fake-exe!
       fake-installer
       (format
        "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > ~s\nprintf '%s\\n' \"${RACKUP_BOOTSTRAP_MODE:-}\" > ~s\nexit 0\n"
        (path->string args-log)
        (path->string mode-log)))
-     (file-or-directory-permissions fake-installer #o755)
      (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
      (dynamic-wind
       (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
@@ -1501,12 +1391,11 @@
      (define fake-installer (build-path tmp "fake-install-update.sh"))
      (define sha-file (build-path tmp ".installed-sha256"))
      (write-string-file sha-file "old-sha")
-     (write-string-file
+     (write-fake-exe!
       fake-installer
       (format
        "#!/bin/sh\nset -eu\nprintf 'new-sha' > ~s\nexit 0\n"
        (path->string sha-file)))
-     (file-or-directory-permissions fake-installer #o755)
      (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
      (dynamic-wind
       (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
@@ -1531,22 +1420,20 @@
      ;; Fake rackup binary at ~/.rackup/bin/rackup that logs invocations
      (make-directory* (build-path tmp "bin"))
      (define fake-rackup (build-path tmp "bin" "rackup"))
-     (write-string-file
+     (write-fake-exe!
       fake-rackup
       (format
        "#!/bin/sh\nprintf '%s\\n' \"$@\" >> ~s\nexit 0\n"
        (path->string reshim-log)))
-     (file-or-directory-permissions fake-rackup #o755)
 
      (define fake-installer (build-path tmp "fake-install-reshim.sh"))
      (define sha-file (build-path tmp ".installed-sha256"))
      (write-string-file sha-file "old-sha")
-     (write-string-file
+     (write-fake-exe!
       fake-installer
       (format
        "#!/bin/sh\nset -eu\nprintf 'new-sha' > ~s\nexit 0\n"
        (path->string sha-file)))
-     (file-or-directory-permissions fake-installer #o755)
      (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
      (dynamic-wind
       (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
@@ -1573,12 +1460,11 @@
      (ensure-index!)
      (define fake-installer (build-path tmp "fake-install-exe.sh"))
      (define args-log (build-path tmp "self-upgrade-exe-args.log"))
-     (write-string-file
+     (write-fake-exe!
       fake-installer
       (format
        "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > ~s\nexit 0\n"
        (path->string args-log)))
-     (file-or-directory-permissions fake-installer #o755)
      (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
      (dynamic-wind
       (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
@@ -1607,13 +1493,12 @@
      (ensure-index!)
      (define fake-installer (build-path tmp "fake-install-ref.sh"))
      (define args-log (build-path tmp "self-upgrade-ref-args.log"))
-     (write-string-file
+     (write-fake-exe!
       fake-installer
       (format
        "#!/bin/sh\nset -eu\n: > ~s\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> ~s; done\nexit 0\n"
        (path->string args-log)
        (path->string args-log)))
-     (file-or-directory-permissions fake-installer #o755)
      (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
      (dynamic-wind
       (lambda () (putenv "RACKUP_SELF_UPGRADE_INSTALL_SH" (path->string fake-installer)))
@@ -1655,21 +1540,15 @@
        (define real-bin (build-path install-root "bin"))
        (make-directory* real-bin)
        (define racket-exe (build-path real-bin "racket"))
-       (write-string-file racket-exe "#!/usr/bin/env bash\necho test\n")
-       (file-or-directory-permissions racket-exe #o755)
+       (write-fake-exe! racket-exe "#!/usr/bin/env bash\necho test\n")
        (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
        (with-state-lock
          (register-toolchain! id
-                              (hash 'id id
-                                    'kind 'release
-                                    'requested-spec version
-                                    'resolved-version version
-                                    'variant variant
-                                    'distribution distribution
-                                    'arch "x86_64"
-                                    'platform "linux"
-                                    'executables '("racket")
-                                    'installed-at "2026-02-26T00:00:00Z"))))
+                              (test-toolchain-meta id
+                                                   #:spec version
+                                                   #:version version
+                                                   'variant variant
+                                                   'distribution distribution))))
 
      (define id-full "release-9.0-cs-x86_64-linux-full")
      (define id-minimal "release-9.0-cs-x86_64-linux-minimal")
@@ -1741,36 +1620,21 @@
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
      (define racket-exe (build-path real-bin "racket"))
-     (write-string-file racket-exe "#!/usr/bin/env bash\necho test\n")
-     (file-or-directory-permissions racket-exe #o755)
+     (write-fake-exe! racket-exe "#!/usr/bin/env bash\necho test\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain! id
-                            (hash 'id id 'kind 'release 'requested-spec "9.0"
-                                  'resolved-version "9.0" 'variant 'cs 'distribution 'full
-                                  'arch "x86_64" 'platform "linux"
-                                  'executables '("racket") 'installed-at "2026-02-26T00:00:00Z")))
+                            (test-toolchain-meta id #:spec "9.0" #:version "9.0")))
 
-     ;; Poison all sanitized Racket env vars
-     (define var-names
-       (for/list ([var (in-list sanitized-racket-env-vars)])
-         (bytes->string/utf-8 var)))
-     (define saved-vars
-       (for/list ([name (in-list var-names)])
-         (cons name (getenv name))))
-     (dynamic-wind
-      (lambda ()
-        (for ([name (in-list var-names)])
-          (putenv name "/nonexistent/poisoned")))
-      (lambda ()
-        ;; rackup list should still work
-        (expect (begin (system* rackup-bin "list") (void))
-                "release-9.0" #:match 'contains))
-      (lambda ()
-        (for ([kv (in-list saved-vars)])
-          (if (cdr kv)
-              (putenv (car kv) (cdr kv))
-              (putenv (car kv) "")))))))
+     ;; Poison all sanitized Racket env vars (in a copied environment so
+     ;; nothing leaks into the rest of the test process).
+     (define env (environment-variables-copy (current-environment-variables)))
+     (for ([var (in-list sanitized-racket-env-vars)])
+       (environment-variables-set! env var #"/nonexistent/poisoned"))
+     (parameterize ([current-environment-variables env])
+       ;; rackup list should still work
+       (expect (begin (system* rackup-bin "list") (void))
+               "release-9.0" #:match 'contains))))
 
   ;; ---- Upgrade path tests ----
   ;; Simulate a 9.0 installation, then "upgrade" by adding 9.1 alongside it.
@@ -1784,29 +1648,23 @@
        (define real-bin (build-path install-root "bin"))
        (make-directory* real-bin)
        (define racket-exe (build-path real-bin "racket"))
-       (write-string-file racket-exe
-                          (format "#!/usr/bin/env bash\nprintf '~a'\n" version))
-       (file-or-directory-permissions racket-exe #o755)
+       (write-fake-exe! racket-exe
+                        (format "#!/usr/bin/env bash\nprintf '~a'\n" version))
        (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
        (with-state-lock
          (register-toolchain! id
-                              (hash 'id id
-                                    'kind 'release
-                                    'requested-spec spec
-                                    'resolved-version version
-                                    'variant 'cs
-                                    'distribution 'full
-                                    'arch "x86_64"
-                                    'platform "linux"
-                                    'snapshot-site #f
-                                    'snapshot-stamp #f
-                                    'installer-url (format "https://example.invalid/racket-~a.sh" version)
-                                    'installer-filename (format "racket-~a-x86_64-linux-cs.sh" version)
-                                    'install-root (path->string install-root)
-                                    'bin-link (path->string (rackup-toolchain-bin-link id))
-                                    'real-bin-dir (path->string real-bin)
-                                    'executables '("racket")
-                                    'installed-at "2026-01-15T00:00:00Z"))))
+                              (test-toolchain-meta
+                               id
+                               #:spec spec
+                               #:version version
+                               'snapshot-site #f
+                               'snapshot-stamp #f
+                               'installer-url (format "https://example.invalid/racket-~a.sh" version)
+                               'installer-filename (format "racket-~a-x86_64-linux-cs.sh" version)
+                               'install-root (path->string install-root)
+                               'bin-link (path->string (rackup-toolchain-bin-link id))
+                               'real-bin-dir (path->string real-bin)
+                               'installed-at "2026-01-15T00:00:00Z"))))
 
      ;; Step 1: Install 9.0 as the initial toolchain (simulating prior state)
      (define id-90 "release-9.0-cs-x86_64-linux-full")
@@ -1886,15 +1744,12 @@
      (define install-root (rackup-toolchain-install-dir id))
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
-     (write-string-file (build-path real-bin "racket") "#!/usr/bin/env bash\nexit 0\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket") "#!/usr/bin/env bash\nexit 0\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain! id
-                            (hash 'id id 'kind 'release 'requested-spec "9.0"
-                                  'resolved-version "9.0" 'variant 'cs 'distribution 'full
-                                  'arch "x86_64" 'platform "linux"
-                                  'executables '("racket") 'installed-at "2026-01-15T00:00:00Z")))
+                            (test-toolchain-meta id #:spec "9.0" #:version "9.0"
+                                                 'installed-at "2026-01-15T00:00:00Z")))
      ;; Re-run ensure-index! (simulating what happens after self-upgrade)
      (define idx3 (ensure-index!))
      (check-true (toolchain-exists? id idx3))
@@ -1909,31 +1764,28 @@
      (define install-root (rackup-toolchain-install-dir id-90))
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
-     (write-string-file (build-path real-bin "racket") "#!/usr/bin/env bash\necho 9.0\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket") "#!/usr/bin/env bash\necho 9.0\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id-90))
      (with-state-lock
        (register-toolchain! id-90
-                            (hash 'id id-90 'kind 'release 'requested-spec "stable"
-                                  'resolved-version "9.0" 'variant 'cs 'distribution 'full
-                                  'arch "x86_64" 'platform "linux"
-                                  'snapshot-site #f 'snapshot-stamp #f
-                                  'installer-url "https://example.invalid/racket-9.0.sh"
-                                  'installer-filename "racket-9.0-x86_64-linux-cs.sh"
-                                  'install-root (path->string install-root)
-                                  'bin-link (path->string (rackup-toolchain-bin-link id-90))
-                                  'real-bin-dir (path->string real-bin)
-                                  'executables '("racket")
-                                  'installed-at "2026-01-15T00:00:00Z")))
+                            (test-toolchain-meta
+                             id-90
+                             #:version "9.0"
+                             'snapshot-site #f 'snapshot-stamp #f
+                             'installer-url "https://example.invalid/racket-9.0.sh"
+                             'installer-filename "racket-9.0-x86_64-linux-cs.sh"
+                             'install-root (path->string install-root)
+                             'bin-link (path->string (rackup-toolchain-bin-link id-90))
+                             'real-bin-dir (path->string real-bin)
+                             'installed-at "2026-01-15T00:00:00Z")))
 
      ;; Fake the self-upgrade: a script that just touches a marker file
      ;; but doesn't modify state (simulating install.sh --prefix preserving state)
      (define fake-installer (build-path tmp "fake-upgrade-install.sh"))
      (define marker-file (build-path tmp "upgrade-ran.marker"))
-     (write-string-file
+     (write-fake-exe!
       fake-installer
       (format "#!/bin/sh\nset -eu\ntouch ~s\n" (path->string marker-file)))
-     (file-or-directory-permissions fake-installer #o755)
 
      (define old-override (getenv "RACKUP_SELF_UPGRADE_INSTALL_SH"))
      (dynamic-wind
@@ -1971,29 +1823,24 @@
        (define real-bin (build-path install-root "bin"))
        (make-directory* real-bin)
        (define racket-exe (build-path real-bin "racket"))
-       (write-string-file racket-exe
-                          (format "#!/usr/bin/env bash\nprintf '~a (~a)'\n" version site))
-       (file-or-directory-permissions racket-exe #o755)
+       (write-fake-exe! racket-exe
+                        (format "#!/usr/bin/env bash\nprintf '~a (~a)'\n" version site))
        (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
        (with-state-lock
          (register-toolchain! id
-                              (hash 'id id
-                                    'kind 'snapshot
-                                    'requested-spec (format "snapshot:~a" site)
-                                    'resolved-version version
-                                    'variant 'cs
-                                    'distribution 'full
-                                    'arch "x86_64"
-                                    'platform "linux"
-                                    'snapshot-site site
-                                    'snapshot-stamp stamp
-                                    'installer-url (format "https://~a.example/snapshots/~a/racket.sh" site stamp)
-                                    'installer-filename (format "racket-~a-x86_64-linux-cs.sh" version)
-                                    'install-root (path->string install-root)
-                                    'bin-link (path->string (rackup-toolchain-bin-link id))
-                                    'real-bin-dir (path->string real-bin)
-                                    'executables '("racket")
-                                    'installed-at "2026-03-01T00:00:00Z")))
+                              (test-toolchain-meta
+                               id
+                               #:spec (format "snapshot:~a" site)
+                               #:version version
+                               'kind 'snapshot
+                               'snapshot-site site
+                               'snapshot-stamp stamp
+                               'installer-url (format "https://~a.example/snapshots/~a/racket.sh" site stamp)
+                               'installer-filename (format "racket-~a-x86_64-linux-cs.sh" version)
+                               'install-root (path->string install-root)
+                               'bin-link (path->string (rackup-toolchain-bin-link id))
+                               'real-bin-dir (path->string real-bin)
+                               'installed-at "2026-03-01T00:00:00Z")))
        id)
 
      ;; Register a Utah snapshot
@@ -2067,29 +1914,24 @@
        (define install-root (rackup-toolchain-install-dir id))
        (define real-bin (build-path install-root "bin"))
        (make-directory* real-bin)
-       (write-string-file (build-path real-bin "racket")
-                          (format "#!/usr/bin/env bash\nprintf '~a'\n" version))
-       (file-or-directory-permissions (build-path real-bin "racket") #o755)
+       (write-fake-exe! (build-path real-bin "racket")
+                        (format "#!/usr/bin/env bash\nprintf '~a'\n" version))
        (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
        (with-state-lock
          (register-toolchain! id
-                              (hash 'id id
-                                    'kind 'snapshot
-                                    'requested-spec "snapshot:utah"
-                                    'resolved-version version
-                                    'variant 'cs
-                                    'distribution 'full
-                                    'arch "x86_64"
-                                    'platform "linux"
-                                    'snapshot-site 'utah
-                                    'snapshot-stamp stamp
-                                    'installer-url (format "https://utah.example/snapshots/~a/racket.sh" stamp)
-                                    'installer-filename (format "racket-~a-x86_64-linux-cs.sh" version)
-                                    'install-root (path->string install-root)
-                                    'bin-link (path->string (rackup-toolchain-bin-link id))
-                                    'real-bin-dir (path->string real-bin)
-                                    'executables '("racket")
-                                    'installed-at "2026-03-01T00:00:00Z")))
+                              (test-toolchain-meta
+                               id
+                               #:spec "snapshot:utah"
+                               #:version version
+                               'kind 'snapshot
+                               'snapshot-site 'utah
+                               'snapshot-stamp stamp
+                               'installer-url (format "https://utah.example/snapshots/~a/racket.sh" stamp)
+                               'installer-filename (format "racket-~a-x86_64-linux-cs.sh" version)
+                               'install-root (path->string install-root)
+                               'bin-link (path->string (rackup-toolchain-bin-link id))
+                               'real-bin-dir (path->string real-bin)
+                               'installed-at "2026-03-01T00:00:00Z")))
        id)
 
      ;; Install old snapshot
@@ -2127,20 +1969,15 @@
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
      (define racket-exe (build-path real-bin "racket"))
-     (write-string-file racket-exe "#!/usr/bin/env bash\necho test\n")
-     (file-or-directory-permissions racket-exe #o755)
+     (write-fake-exe! racket-exe "#!/usr/bin/env bash\necho test\n")
      (define print-env (build-path real-bin "print-compiled-roots"))
-     (write-string-file print-env
-                        "#!/usr/bin/env bash\nprintf 'PLTCOMPILEDROOTS=%s\\n' \"${PLTCOMPILEDROOTS:-}\"\n")
-     (file-or-directory-permissions print-env #o755)
+     (write-fake-exe! print-env
+                      "#!/usr/bin/env bash\nprintf 'PLTCOMPILEDROOTS=%s\\n' \"${PLTCOMPILEDROOTS:-}\"\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
      (with-state-lock
        (register-toolchain! id
-                            (hash 'id id 'kind 'release 'requested-spec "9.0"
-                                  'resolved-version "9.0" 'variant 'cs 'distribution 'full
-                                  'arch "x86_64" 'platform "linux"
-                                  'executables '("racket" "print-compiled-roots")
-                                  'installed-at "2026-02-26T00:00:00Z")))
+                            (test-toolchain-meta id #:spec "9.0" #:version "9.0"
+                                                 'executables '("racket" "print-compiled-roots"))))
 
      (define old-cr (getenv "PLTCOMPILEDROOTS"))
      (dynamic-wind
@@ -2203,13 +2040,11 @@
      (define install-root (rackup-toolchain-install-dir id))
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
-     (write-string-file (build-path real-bin "racket")
-                        "#!/usr/bin/env bash\necho test\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket")
+                      "#!/usr/bin/env bash\necho test\n")
      (define print-cr (build-path real-bin "print-compiled-roots"))
-     (write-string-file print-cr
-                        "#!/usr/bin/env bash\nprintf 'PLTCOMPILEDROOTS=%s\\n' \"${PLTCOMPILEDROOTS:-}\"\n")
-     (file-or-directory-permissions print-cr #o755)
+     (write-fake-exe! print-cr
+                      "#!/usr/bin/env bash\nprintf 'PLTCOMPILEDROOTS=%s\\n' \"${PLTCOMPILEDROOTS:-}\"\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
 
      ;; Simulate install-time env-var computation
@@ -2223,13 +2058,14 @@
 
      (with-state-lock
        (register-toolchain! id
-                            (hash 'id id 'kind 'release 'requested-spec "9.1"
-                                  'resolved-version "9.1" 'variant 'cs 'distribution 'full
-                                  'arch "x86_64" 'platform "linux"
-                                  'env-vars (for/list ([kv (in-list env-vars)])
-                                              (list (car kv) (cdr kv)))
-                                  'executables '("racket" "print-compiled-roots")
-                                  'installed-at "2026-03-01T00:00:00Z")))
+                            (test-toolchain-meta
+                             id
+                             #:spec "9.1"
+                             #:version "9.1"
+                             'env-vars (for/list ([kv (in-list env-vars)])
+                                         (list (car kv) (cdr kv)))
+                             'executables '("racket" "print-compiled-roots")
+                             'installed-at "2026-03-01T00:00:00Z")))
      ;; Write the env.sh as the install flow would
      (write-toolchain-env-file! id env-vars)
 
@@ -2292,24 +2128,20 @@
      ;; Racket program that uses pkg/lib.  Only -e invocations matter;
      ;; ignore other raco subcommands for this test.
      (define racket-exe (build-path real-bin "racket"))
-     (write-string-file racket-exe
-                        (string-append
-                         "#!/usr/bin/env bash\n"
-                         "if [ \"${1:-}\" = \"-e\" ]; then\n"
-                         "  printf '%s\\n' " (sh-single-quote (path->string pkg-dir)) "\n"
-                         "  exit 0\n"
-                         "fi\n"
-                         "exit 0\n"))
-     (file-or-directory-permissions racket-exe #o755)
+     (write-fake-exe! racket-exe
+                      (string-append
+                       "#!/usr/bin/env bash\n"
+                       "if [ \"${1:-}\" = \"-e\" ]; then\n"
+                       "  printf '%s\\n' " (sh-single-quote (path->string pkg-dir)) "\n"
+                       "  exit 0\n"
+                       "fi\n"
+                       "exit 0\n"))
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
 
      (with-state-lock
        (register-toolchain! id
-                            (hash 'id id 'kind 'release 'requested-spec "9.1"
-                                  'resolved-version "9.1" 'variant 'cs 'distribution 'full
-                                  'arch "x86_64" 'platform "linux"
-                                  'executables '("racket")
-                                  'installed-at "2026-03-01T00:00:00Z")))
+                            (test-toolchain-meta id #:spec "9.1" #:version "9.1"
+                                                 'installed-at "2026-03-01T00:00:00Z")))
 
      ;; Sanity: all three compiled dirs exist up front
      (check-true (directory-exists? (build-path pkg-dir "compiled" "9.1-cs")))
@@ -2370,14 +2202,14 @@
 
          (with-state-lock
            (register-toolchain! id
-                                (hash 'id id 'kind 'release 'requested-spec "test"
-                                      'resolved-version "test" 'variant 'cs
-                                      'distribution 'full 'arch "x86_64"
-                                      'platform "linux"
-                                      'env-vars (for/list ([kv (in-list env-vars)])
-                                                  (list (car kv) (cdr kv)))
-                                      'executables '("racket" "raco")
-                                      'installed-at "2026-04-01T00:00:00Z"))
+                                (test-toolchain-meta
+                                 id
+                                 #:spec "test"
+                                 #:version "test"
+                                 'env-vars (for/list ([kv (in-list env-vars)])
+                                             (list (car kv) (cdr kv)))
+                                 'executables '("racket" "raco")
+                                 'installed-at "2026-04-01T00:00:00Z"))
            (set-default-toolchain! id)
            (reshim!))
          ;; Write env.sh so the shim dispatcher picks up PLTCOMPILEDROOTS
@@ -2528,22 +2360,17 @@
      (define install-root (rackup-toolchain-install-dir id))
      (define real-bin (build-path install-root "bin"))
      (make-directory* real-bin)
-     (write-string-file (build-path real-bin "racket")
-                        "#!/usr/bin/env bash\nexit 0\n")
-     (file-or-directory-permissions (build-path real-bin "racket") #o755)
+     (write-fake-exe! (build-path real-bin "racket")
+                      "#!/usr/bin/env bash\nexit 0\n")
      (make-file-or-directory-link real-bin (rackup-toolchain-bin-link id))
 
      ;; Register the toolchain as if it had been installed by an older
      ;; rackup: env-vars is empty (no PLTCOMPILEDROOTS).
      (with-state-lock
        (register-toolchain! id
-                            (hash 'id id 'kind 'release 'requested-spec "9.1"
-                                  'resolved-version "9.1" 'variant 'cs
-                                  'distribution 'full 'arch "x86_64"
-                                  'platform "linux"
-                                  'env-vars '()
-                                  'executables '("racket")
-                                  'installed-at "2026-02-01T00:00:00Z")))
+                            (test-toolchain-meta id #:spec "9.1" #:version "9.1"
+                                                 'env-vars '()
+                                                 'installed-at "2026-02-01T00:00:00Z")))
 
      ;; Sanity: nothing has PLTCOMPILEDROOTS yet
      (check-false (assoc "PLTCOMPILEDROOTS" (toolchain-env-vars id))
@@ -2596,11 +2423,10 @@
 
      ;; Fake racket that returns NEW values on probe (different from
      ;; what was stored in meta).
-     (write-string-file (build-path bin-dir "racket")
-                        (fake-racket-script
-                         #:version "9.7.0.5"
-                         #:addon-dir new-addon))
-     (file-or-directory-permissions (build-path bin-dir "racket") #o755)
+     (write-fake-exe! (build-path bin-dir "racket")
+                      (fake-racket-script
+                       #:version "9.7.0.5"
+                       #:addon-dir new-addon))
 
      (define id "local-stale")
      (define real-bin-link (rackup-toolchain-bin-link id))

--- a/test/switch-install.rkt
+++ b/test/switch-install.rkt
@@ -113,7 +113,8 @@
    (lambda ()
      (delete-directory/files tmp-home #:must-exist? #f))))
 
-(with-temp-rackup-home
+(module+ test
+ (with-temp-rackup-home
  (lambda (_tmp-home)
    (define stdout-str (open-output-string))
    (define stderr-str (open-output-string))
@@ -145,4 +146,4 @@
                  (format "non-shell-code line on switch stdout: ~s" line)))
    ;; The progress messages still reach the user, on stderr.
    (check-true (string-contains? err "Installing")
-               (format "install progress missing from stderr: ~s" err))))
+               (format "install progress missing from stderr: ~s" err)))))

--- a/test/version.rkt
+++ b/test/version.rkt
@@ -6,7 +6,7 @@
          "../libexec/rackup/main.rkt")
 
 (module+ test
-  (define output (string-trim (with-output-to-string cmd-version)))
+  (define output (string-trim (with-output-to-string (lambda () (cmd-version '())))))
 
   (check-true (string-prefix? output "rackup "))
   ;; In a git repo, we should get a commit hash


### PR DESCRIPTION
Deduplication:
- Merge the two near-identical copies of `ensure-installer-cached!` (install.rkt, runtime.rkt) into installer-backend.rkt with an `#:announce` hook for the differing progress messages.
- Drop install.rkt's copy of the env.sh writer/deleter in favor of the shims.rkt version; add `sync-toolchain-env-file!` for the write-or-delete conditional repeated at three call sites.
- Move `toolchain-runtime-env`, `toolchain-env-var-entries`, and `env-vars->meta` into state.rkt, replacing copies in install.rkt, main.rkt, and shims.rkt.
- install.sh: extract `install_binary_distribution()` shared by the CI-artifact and published-binary paths (the CI path now also gets the macOS ad-hoc codesign step it was missing), plus `extract_tarball_dir()`, `download_stdout()`, and `reshim_and_store_checksum()`; call the bundled scripts/copy-filtered-tree.sh instead of an inline copy.
- bin/rackup: one `rackup_save_and_clear_racket_env` helper instead of two near-identical blocks; drop the unused `rackup_run_core` function and the vestigial PLTHOME save that nothing restores.
- Share the `_rackup_toolchains` completion function between the bash and zsh templates via templates/toolchains-fn.scrbl.
- test/state-shims.rkt: `write-fake-exe!` and `test-toolchain-meta` helpers replace ~45 write+chmod pairs and ~19 verbose metadata hash literals (2662 -> 2488 lines).

Standard-library replacements:
- rktd-io.rkt: delegate to racket/file's `call-with-atomic-output-file`, keeping permission preservation as a thin wrapper.
- main.rkt: `splitf-at` for `split-on-double-dash`; `~a #:min-width` for usage alignment.
- install.rkt: `argmax` (over a path-sorted list, preserving the deterministic tiebreak) for the Chez executable scoring.
- Convert install.rkt and shell.rkt from `#lang at-exp` to plain racket/base (generated output is byte-identical), satisfying the no-at-exp-in-client-code invariant test.

New reusable abstractions:
- error.rkt: `try-or` macro for the pervasive swallow-and-default with-handlers pattern (20 call sites converted).
- fs.rkt: `delete-path!` and `dir-or-link-exists?`.
- process.rkt: `call-with-env-overlay`, used by `capture-program-output`, package migration, and self-upgrade; `run-quiet-program` moved here from runtime.rkt.
- text.rkt: `yes-answer?` for interactive y/N prompts.

Test-suite coverage fix: test/all.rkt required each test file's main module, but every test file wraps its checks in `(module+ test ...)`, so CI ran only 316 of 955 tests. all.rkt now requires the `test` submodules. Latent bugs this exposed, all fixed here: a putenv-based env restore that left `PLTUSERHOME=""` (poisoning `find-system-path 'home-dir` for later tests), a namespace-dependent `compile` call in test/rktd-io.rkt, and a missing argument in test/version.rkt.

Considered and rejected: version/utils for versioning.rkt (must order PLT Scheme versions like 103/372 that `valid-version?` rejects), net/head's `extract-field` (headers arrive as a list of byte strings), and `fold-files` for `for-each-named-subdir` (the explicit walk is clearer). Details archived in docs/plans/2026-06-09-dedup-and-stdlib-refactor.md.

Verified: `raco test -y test/all.rkt` (955 tests, 0 failures), shellcheck/shfmt clean on all shell scripts, `raco make libexec/rackup-core.rkt` clean.
