### PR TITLE
Keep `rackup switch` stdout eval-clean when it offers to install

### DIFF
--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -184,14 +184,21 @@
         "__no__"))
   (or (string=? a "") (member a '("y" "yes"))))
 
+;; Open the controlling terminal for interactive prompts.  A parameter
+;; so tests can substitute string ports.
+(define current-open-user-tty
+  (make-parameter
+   (lambda ()
+     (values (open-input-file "/dev/tty")
+             (open-output-file "/dev/tty" #:exists 'append)))))
+
 (define (call-with-user-tty proc)
   (with-handlers ([exn:fail?
                    (lambda (_)
                      (and (terminal-port? (current-input-port))
                           (terminal-port? (current-error-port))
                           (proc (current-input-port) (current-error-port))))])
-    (define tty-in (open-input-file "/dev/tty"))
-    (define tty-out (open-output-file "/dev/tty" #:exists 'append))
+    (define-values (tty-in tty-out) ((current-open-user-tty)))
     (dynamic-wind void
                   (lambda () (proc tty-in tty-out))
                   (lambda ()
@@ -395,7 +402,11 @@
   (cond
     [deactivate? (display (emit-shell-deactivation))]
     [(= (length args) 1)
-     (define id (resolve-toolchain-or-die (first args)))
+     ;; As with `rackup switch`, stdout is eval'd by the shell function
+     ;; and must carry only shell code.
+     (define id
+       (parameterize ([current-output-port (current-error-port)])
+         (resolve-toolchain-or-die (first args))))
      (display (emit-shell-activation id))]
     [else (rackup-error "usage: rackup shell <toolchain> | rackup shell --deactivate")]))
 
@@ -413,7 +424,17 @@
   (cond
     [unset? (display (emit-shell-deactivation))]
     [(= (length args) 1)
-     (define id (resolve-toolchain-or-offer-install (first args)))
+     ;; The shell-integration function evals the stdout of `rackup
+     ;; switch`, so stdout must carry only the activation shell code.
+     ;; Route everything else -- notably install progress when the user
+     ;; accepts the offer to install -- to stderr.
+     ;; The shell-integration function evals the stdout of `rackup
+     ;; switch`, so stdout must carry only the activation shell code.
+     ;; Route everything else -- notably install progress when the user
+     ;; accepts the offer to install -- to stderr.
+     (define id
+       (parameterize ([current-output-port (current-error-port)])
+         (resolve-toolchain-or-offer-install (first args))))
      (display (emit-shell-activation id))]
     [else (rackup-error "usage: rackup switch <toolchain> | rackup switch --unset")]))
 
@@ -1138,5 +1159,6 @@
            validate-uninstall-home-path!
            delete-rackup-home!/external
            installed-toolchain-metas/safe
+           current-open-user-tty
            current-remove-shell-init-blocks-proc
            current-uninstall-system*-proc))

--- a/test/all.rkt
+++ b/test/all.rkt
@@ -13,6 +13,7 @@
          "security.rkt"
          "shell-completion.rkt"
          "state-shims.rkt"
+         "switch-install.rkt"
          "text.rkt"
          "uninstall.rkt"
          "upgrade.rkt"

--- a/test/switch-install.rkt
+++ b/test/switch-install.rkt
@@ -1,0 +1,148 @@
+#lang racket/base
+
+;; Regression test for `rackup switch <spec>` when the toolchain is not
+;; installed and the user accepts the offer to install it.  The shell
+;; integration function evals the stdout of `rackup switch`, so stdout
+;; must carry only shell code; install progress must go to stderr.
+;; (Reported by Matthias: zsh printed "(eval):1: command not found:
+;; Installing" after accepting the install prompt.)
+;;
+;; The whole install runs offline: HTTP is stubbed via
+;; current-http-sendrecv-proc and the /dev/tty prompt via
+;; current-open-user-tty.
+
+(require rackunit
+         racket/file
+         racket/port
+         racket/string
+         racket/system
+         "../libexec/rackup/main.rkt"
+         "../libexec/rackup/state.rkt"
+         "../libexec/rackup/versioning.rkt"
+         (only-in (submod "../libexec/rackup/main.rkt" for-testing)
+                  current-open-user-tty)
+         (only-in (submod "../libexec/rackup/remote.rkt" for-testing)
+                  current-http-sendrecv-proc))
+
+(define (run-main args)
+  (let/ec escape
+    (parameterize ([current-command-line-arguments (list->vector args)]
+                   [exit-handler (lambda (v) (escape v))])
+      (main))))
+
+(define arch (normalized-host-arch))
+(define platform (host-platform-token))
+(define ext (if (equal? platform "macosx") "tgz" "sh"))
+(define installer-filename (format "racket-9.1-~a-~a-cs.~a" arch platform ext))
+
+;; A fake modern .sh installer: the header markers make
+;; detect-shell-installer-mode classify it as 'modern, and it honors
+;; --dest by creating a minimal bin/racket there.
+(define fake-sh-installer
+  (string-join
+   '("#!/bin/sh"
+     "# Command-line flags: --dest <dir> --in-place (fake test installer)"
+     "dest="
+     "while [ \"$#\" -gt 0 ]; do"
+     "  case \"$1\" in"
+     "    --dest) dest=\"$2\"; shift 2 ;;"
+     "    *) shift ;;"
+     "  esac"
+     "done"
+     "mkdir -p \"$dest/bin\""
+     "printf '#!/bin/sh\\necho fake-racket\\n' > \"$dest/bin/racket\""
+     "chmod 755 \"$dest/bin/racket\""
+     "")
+   "\n"))
+
+;; A fake .tgz installer (used on macOS, where .tgz is preferred):
+;; a real gzipped tarball containing bin/racket.
+(define (make-fake-tgz-bytes)
+  (define stage (make-temporary-file "rackup-fake-stage-~a" 'directory))
+  (define bin (build-path stage "bin"))
+  (make-directory* bin)
+  (call-with-output-file* (build-path bin "racket")
+    (lambda (out) (display "#!/bin/sh\necho fake-racket\n" out)))
+  (file-or-directory-permissions (build-path bin "racket") #o755)
+  (define tgz (make-temporary-file "rackup-fake-~a.tgz"))
+  (unless (system* (find-executable-path "tar")
+                   "-C" stage "-czf" tgz "bin")
+    (error 'switch-install-test "failed to build fake tgz"))
+  (define bs (file->bytes tgz))
+  (delete-file tgz)
+  (delete-directory/files stage)
+  bs)
+
+(define installer-bytes
+  (if (equal? ext "tgz")
+      (make-fake-tgz-bytes)
+      (string->bytes/utf-8 fake-sh-installer)))
+
+(define table-rktd-text
+  (format "~s" (hash 'installer installer-filename)))
+
+(define (fake-http-response target)
+  (cond
+    [(string-suffix? target "/version.txt")
+     (string->bytes/utf-8 "(stable \"9.1\")")]
+    [(string-suffix? target "table.rktd")
+     (string->bytes/utf-8 table-rktd-text)]
+    [(string-suffix? target installer-filename)
+     installer-bytes]
+    [(regexp-match? #px"/releases/" target)
+     #"<html></html>"]
+    [else (error 'switch-install-test "unexpected HTTP request: ~a" target)]))
+
+(define fake-http-sendrecv
+  (make-keyword-procedure
+   (lambda (_kws _kw-args _host target . _rest)
+     (values #"HTTP/1.1 200 OK"
+             null
+             (open-input-bytes (fake-http-response target))))))
+
+(define (with-temp-rackup-home proc)
+  (define tmp-home (make-temporary-file "rackup-switch-home-~a" 'directory))
+  (define env (environment-variables-copy (current-environment-variables)))
+  (environment-variables-set! env #"RACKUP_HOME" (string->bytes/utf-8 (path->string tmp-home)))
+  (environment-variables-set! env #"RACKUP_TOOLCHAIN" #f)
+  (dynamic-wind
+   void
+   (lambda ()
+     (parameterize ([current-environment-variables env])
+       (proc tmp-home)))
+   (lambda ()
+     (delete-directory/files tmp-home #:must-exist? #f))))
+
+(with-temp-rackup-home
+ (lambda (_tmp-home)
+   (define stdout-str (open-output-string))
+   (define stderr-str (open-output-string))
+   (define exit-code
+     (parameterize ([current-http-sendrecv-proc fake-http-sendrecv]
+                    [current-open-user-tty
+                     (lambda ()
+                       (values (open-input-string "Y\n") (open-output-nowhere)))]
+                    [current-output-port stdout-str]
+                    [current-error-port stderr-str]
+                    [current-input-port (open-input-string "")])
+       (run-main '("switch" "stable"))))
+   (define out (get-output-string stdout-str))
+   (define err (get-output-string stderr-str))
+   (check-equal? exit-code (void)
+                 (format "switch exited non-zero; stderr: ~s" err))
+   (define expected-id (format "release-9.1-cs-~a-~a-full" arch platform))
+   ;; The toolchain really was installed and registered.
+   (check-true (toolchain-exists? expected-id)
+               (format "expected ~a to be installed; stderr: ~a" expected-id err))
+   ;; stdout carries the activation shell code...
+   (check-true (string-contains? out (format "export RACKUP_TOOLCHAIN='~a'" expected-id))
+               (format "activation code missing from stdout: ~s" out))
+   ;; ...and nothing else: the install progress must not leak into the
+   ;; eval'd output (every stdout line must be shell code).
+   (for ([line (in-list (string-split out "\n"))]
+         #:unless (string=? (string-trim line) ""))
+     (check-true (regexp-match? #px"^(if |  case |fi$|export |unset )" line)
+                 (format "non-shell-code line on switch stdout: ~s" line)))
+   ;; The progress messages still reach the user, on stderr.
+   (check-true (string-contains? err "Installing")
+               (format "install progress missing from stderr: ~s" err))))


### PR DESCRIPTION
The shell-integration rackup() function captures the stdout of `rackup switch <spec>` and evals it to set RACKUP_TOOLCHAIN in the parent shell. When `<spec>` was not installed and the user accepted the "Install it now?" prompt, the install progress ("Installing ...", "Downloading installer...", "Installed ...", and the default-toolchain notice) was printed to stdout and therefore eval'd as shell commands:

    (eval):1: command not found: Installing
    (eval):2: command not found: Downloading
    (eval):3: command not found: Installed

Route everything except the emitted activation shell code to stderr in cmd-switch (and cmd-shell, whose stdout is eval'd the same way), so progress messages still reach the user without corrupting the eval.

The new test drives the full switch-with-install flow offline: HTTP is stubbed via `current-http-sendrecv-proc`, the /dev/tty prompt via the new `current-open-user-tty` parameter, and a fake installer (.sh on Linux, .tgz on macOS) provides bin/racket. It asserts that every stdout line is shell code and that the progress messages appear on stderr; before the fix it fails with exactly the lines from the bug report.
