### PR TITLE
Add a `rackup agents` guide for AI agents and automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           version: stable
       - name: Install Pages build deps
         shell: bash
-        run: raco pkg install --auto --skip-installed --batch plt-web
+        run: raco pkg install --auto --skip-installed --batch plt-web commonmark
       - name: Download all exe artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
           version: stable
       - name: Install Pages build deps
         run: |
-          raco pkg install --auto plt-web
+          raco pkg install --auto --skip-installed --batch plt-web commonmark
       - name: Download all exe artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,20 @@ not `racket` through the rackup shim. The shim dispatcher saves,
 unsets, and re-sets Racket env vars, so testing through the shim
 gives misleading results about Racket's native behavior.
 
+## Agent-facing docs
+
+Two different audiences, two different files — don't conflate them:
+
+- **This file** (`CLAUDE.md`, and its `AGENTS.md` symlink) is for agents
+  *contributing to rackup*. `AGENTS.md` is a symlink to `CLAUDE.md` so
+  non-Claude tools (Codex, Cursor, Aider, Gemini CLI, …) pick up the same
+  contributor rules.
+- The guide for agents *using rackup as a tool* is a single source of truth in
+  `libexec/rackup/agents-guide.rkt` (`agent-guide-text`). It is printed by
+  `rackup help agents`, published at `agents.html` and `agents-snippet.md` by
+  the Pages build, and drift-guarded by `test/agents-guide.rkt`. Edit the
+  string in that module; do not duplicate its content elsewhere.
+
 ## Code ownership
 
 We own the entire project. There is no public API. Feel free to change any module's exports, signatures, or internal structure as needed — no backwards-compatibility workarounds required.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ rackup reshim --short-aliases
 | `plt-fresh-build` | Build manually, then `rackup link` |
 | `r` / `dr` aliases | `rackup reshim --short-aliases` |
 
+## For AI agents and automation
+
+Driving rackup from CI, a script, or an AI coding agent? Run `rackup help agents`
+for a cheat sheet (also published at
+**[samth.github.io/rackup/agents.html](https://samth.github.io/rackup/agents.html)**).
+
+The one rule that matters: to run a tool under a specific toolchain
+non-interactively, use `rackup run <toolchain> -- <command>` (e.g.
+`rackup run stable -- raco test .`). It needs no shell integration, unlike
+`rackup switch`, which only takes effect in an interactive shell. State is
+available in line-oriented form via `rackup list --ids`, `rackup current line`,
+`rackup default status`, and `rackup which`.
+
+A short snippet to drop into your project's `AGENTS.md`/`CLAUDE.md` is published at
+**[agents-snippet.md](https://samth.github.io/rackup/agents-snippet.md)**.
+
 ## Documentation
 
 Full command reference and usage guide: **[samth.github.io/rackup/docs.html](https://samth.github.io/rackup/docs.html)**

--- a/docs/rackup-navbar.js
+++ b/docs/rackup-navbar.js
@@ -5,6 +5,7 @@
   nav.innerHTML = [
     '<a class="logo" href="https://samth.github.io/rackup/">rackup</a>',
     '<a href="docs.html">Docs</a>',
+    '<a href="agents.html">Agents</a>',
     '<a href="https://samth.github.io/rackup/install.sh">install.sh</a>',
     '<a href="https://github.com/samth/rackup">GitHub</a>',
     '<a href="https://github.com/samth/rackup/blob/main/README.md">README</a>'

--- a/docs/rackup.scrbl
+++ b/docs/rackup.scrbl
@@ -649,6 +649,24 @@ Reports on:
 
 @; ────────────────────────────────────────────────────────────────────
 
+@section[#:tag "agents" #:style 'unnumbered]{@tt{rackup agents}}
+
+Print a guide for driving rackup non-interactively — from CI, scripts, or
+an AI coding agent.  @tt{rackup help agents} prints the same text.
+
+@shell-block{rackup agents}
+
+The guide is the single source of truth in
+@tt{libexec/rackup/agents-guide.rkt}; it is also published at
+@hyperlink["https://samth.github.io/rackup/agents.html"]{samth.github.io/rackup/agents.html},
+with a short paste-in version for your own project at
+@hyperlink["https://samth.github.io/rackup/agents-snippet.md"]{agents-snippet.md}.
+The one rule it stresses: to run a tool under a specific toolchain in a
+script, use @tt{rackup run <toolchain> -- <command>} rather than
+@tt{rackup switch}, which only takes effect in an interactive shell.
+
+@; ────────────────────────────────────────────────────────────────────
+
 @section[#:tag "version" #:style 'unnumbered]{@tt{rackup version}}
 
 Print rackup version information (git commit hash and date).

--- a/libexec/rackup/agents-guide.rkt
+++ b/libexec/rackup/agents-guide.rkt
@@ -1,0 +1,186 @@
+#lang racket/base
+
+;; Single source of truth for the "rackup for agents" guide.
+;;
+;; `agent-guide-text` is printed verbatim by `rackup help agents`
+;; (embedded in the compiled binary, so it works in the prebuilt exe)
+;; and rendered to agents.html by the Pages build
+;; (pages/build-pages-site.rkt).  `agent-snippet-text` is the short
+;; paste-in block published at agents-snippet.md.
+;;
+;; The guide is Markdown: it reads fine as plain text in a terminal and
+;; renders to HTML on the docs site.  Keep it in sync with the actual
+;; command surface — test/agents-guide.rkt cross-checks
+;; `agent-guide-referenced-commands` against commands-data.rkt so a
+;; renamed/removed command cannot silently rot the guide.
+
+(provide agent-guide-text
+         agent-snippet-text
+         agent-guide-referenced-commands)
+
+(define agent-guide-text
+  #<<RACKUP-AGENT-GUIDE-END
+# Using rackup from an AI agent or automation
+
+rackup is a toolchain manager for Racket: it installs Racket versions and
+selects which one `racket`, `raco`, `scribble`, etc. resolve to. This is the
+cheat sheet for driving rackup non-interactively — from CI, scripts, or a
+coding agent. Print it any time with `rackup help agents`.
+
+## TL;DR
+
+    rackup install stable                  # install a toolchain (idempotent)
+    rackup run stable -- racket --version  # run a tool under it, no shell setup
+    rackup run stable -- raco test .       # run your project's tests
+    rackup list --ids                      # installed toolchain IDs, one per line
+    rackup which racket                    # real path of the active `racket`
+
+The one rule that matters: to run a tool under a specific toolchain, use
+`rackup run <toolchain> -- <command>`. It configures everything for that one
+subprocess and needs no shell integration. Do not rely on `rackup switch` in
+scripts (see Gotchas).
+
+## Why `rackup run`, not `rackup switch`
+
+`rackup switch` only takes effect through the shell function that `rackup init`
+installs into an interactive `.bashrc`/`.zshrc`. A non-interactive shell
+(`bash -c`, a CI step, an agent tool call) never loads that function, so
+
+    rackup switch 8.18 && raco test .      # WRONG: runs the *default* toolchain
+
+silently runs whatever the default toolchain is, not 8.18. `rackup run` has no
+such dependency:
+
+    rackup run 8.18 -- raco test .         # RIGHT: always 8.18
+
+`rackup run` scopes `PLTHOME`, `PLTADDONDIR`, `PATH`, and `RACKUP_TOOLCHAIN` to
+the subprocess only, and passes through any Racket env vars you already set.
+
+## Machine-readable commands
+
+Parse these line-oriented outputs; do not scrape the human-formatted tables:
+
+- `rackup list --ids` — installed toolchain IDs, one per line
+- `rackup current id` — the active toolchain ID, or blank if none
+- `rackup current line` — the active ID, a TAB, then `env` or `default`
+- `rackup default status` — `set`, a TAB, then the ID; or just `unset`
+- `rackup which racket` — absolute path of a tool in the active toolchain
+- `rackup which raco --toolchain 8.18` — absolute path in a specific toolchain
+- `rackup available` — installable versions and channels
+
+## Toolchain specs
+
+A `<toolchain>` is either an installed ID (see `rackup list --ids`) or, for
+`rackup install`, one of:
+
+- a release number: `8.18`, `7.9`, `4.2.5`
+- `stable` — the current stable release
+- `pre-release` — the latest pre-release build
+- `snapshot`, `snapshot:utah`, `snapshot:northwestern` — the latest snapshot
+
+Pin an explicit version when you need reproducibility; use `stable` when you
+just want a working Racket.
+
+## Recipes
+
+Install and test under a specific version:
+
+    rackup install 8.18
+    rackup run 8.18 -- raco test .
+
+Read the Racket version string programmatically:
+
+    rackup run stable -- racket -e '(display (version))'
+
+Install packages into a toolchain's addon dir:
+
+    rackup run stable -- raco pkg install --auto gregor
+
+Use a locally built Racket checkout:
+
+    rackup link dev ~/src/racket
+    rackup run dev -- racket --version
+
+Find the real binary (e.g. to hand an absolute path to another tool):
+
+    rackup which racket
+    rackup which raco --toolchain 8.18
+
+Check what is installed / active before acting:
+
+    rackup list --ids
+    rackup current line
+
+## Non-interactive behavior
+
+- rackup does not hang waiting for input when there is no terminal. Asking to
+  `run`/`default`/`switch` a toolchain that is not installed errors
+  immediately, hinting that you should run `rackup install <spec>` first,
+  rather than blocking on a prompt. So always install before you use.
+- `rackup install` is idempotent: re-running with an already-installed spec is
+  a no-op (add `--force` to reinstall), so it is safe to run unconditionally.
+- Quiet a noisy install with `rackup install <spec> --quiet`.
+- The only destructive command that prompts is `rackup uninstall`; it refuses
+  to run without a terminal unless you pass
+  `--dangerously-delete-without-prompting`. Do not run it in automation unless
+  that is the explicit goal.
+
+## Exit codes
+
+- `0` — success
+- `1` — runtime error (network, filesystem, internal)
+- `2` — usage error (unknown command or bad flags) or "toolchain not installed"
+
+Branch on the exit status; do not match on stderr text.
+
+## Anti-patterns
+
+- Avoid `rackup switch X && raco ...` in a script — it runs the default
+  toolchain. Use `rackup run X -- raco ...` instead.
+- Avoid assuming a toolchain exists. Install it first: `rackup install X`.
+- Avoid parsing `rackup list` or `rackup doctor` for state. Use
+  `rackup list --ids`, `rackup current line`, `rackup default status`, and
+  `rackup which` instead.
+- Avoid editing `~/.rackup` by hand. Use rackup commands; the on-disk layout is
+  internal and may change.
+
+## Drop this into your project's AGENTS.md / CLAUDE.md
+
+A short version of the above, suitable for pasting into a project so other
+agents know how to run its Racket toolchain, is published at
+<https://samth.github.io/rackup/agents-snippet.md>.
+RACKUP-AGENT-GUIDE-END
+  )
+
+(define agent-snippet-text
+  #<<RACKUP-AGENT-SNIPPET-END
+## Racket via rackup
+
+This project's Racket toolchain is managed by
+[rackup](https://samth.github.io/rackup/).
+
+- Run Racket tools through the toolchain with `rackup run <toolchain> -- <cmd>`,
+  e.g. `rackup run stable -- raco test .`. Do NOT use `rackup switch` in
+  scripts — it only takes effect in interactive shells.
+- Install the toolchain first if needed: `rackup install stable` (idempotent).
+- Machine-readable state: `rackup list --ids`, `rackup current line`,
+  `rackup which racket`.
+- Full agent guide: `rackup help agents`.
+RACKUP-AGENT-SNIPPET-END
+  )
+
+;; Commands the guide teaches.  test/agents-guide.rkt asserts each is a
+;; real subcommand (present in commands-data.rkt) and is actually
+;; mentioned in the guide text, so the guide cannot reference a command
+;; that has been renamed or removed.
+(define agent-guide-referenced-commands
+  '("install" "run"
+              "list"
+              "which"
+              "current"
+              "default"
+              "available"
+              "link"
+              "switch"
+              "uninstall"
+              "help"))

--- a/libexec/rackup/commands-data.rkt
+++ b/libexec/rackup/commands-data.rkt
@@ -31,6 +31,7 @@
     ("self-upgrade" . "Upgrade rackup code")
     ("runtime"      . "Manage internal runtime")
     ("doctor"       . "Print diagnostics")
+    ("agents"       . "Print a guide for AI agents and automation")
     ("version"      . "Print version info")
     ("help"         . "Show help")))
 

--- a/libexec/rackup/main.rkt
+++ b/libexec/rackup/main.rkt
@@ -16,6 +16,7 @@
                      racket/syntax
                      "commands-data.rkt")
          "commands-data.rkt"
+         "agents-guide.rkt"
          "install.rkt"
          "legacy-plt-catalog.rkt"
          "mac-apps.rkt"
@@ -115,12 +116,14 @@
   (usage-line "runtime status|install|upgrade"
               "Manage rackup's hidden internal runtime used to run rackup itself.")
   (usage-line "doctor" "Print diagnostics for paths, runtime, and installed toolchains.")
+  (usage-line "agents" "Print a guide for driving rackup from an AI agent or automation.")
   (usage-line "version" "Print rackup version info (git commit and date).")
   (usage-line "help [command]" "Show global help or help for a specific command.")
   (displayln "")
   (displayln version-help)
   (displayln "")
-  (displayln "Use `rackup <command> --help` or `rackup help <command>` for command help."))
+  (displayln "Use `rackup <command> --help` or `rackup help <command>` for command help.")
+  (displayln "Automating rackup (CI, scripts, coding agents)? See `rackup help agents`."))
 
 ;; If spec is a meta-name like "stable", try resolving it to an actual
 ;; version number and look up locally.  Returns the ID or #f.
@@ -1112,6 +1115,12 @@
                 #:args ()
                 (void))
   (doctor-report))
+
+;; `rackup agents` / `rackup help agents` (which dispatches here as
+;; `agents --help`) both print the agent guide, which is itself the help
+;; for this command.  Any extra args are ignored on purpose.
+(define (cmd-agents _rest)
+  (displayln agent-guide-text))
 
 ;; Build a name → handler lookup table from `rackup-commands` at compile
 ;; time, skipping `help` (dispatched by hand).  Adding a new subcommand

--- a/pages/build-pages-site.rkt
+++ b/pages/build-pages-site.rkt
@@ -10,7 +10,9 @@
          racket/system
          file/sha1
          net/url
-         "../libexec/rackup/remote.rkt")
+         commonmark
+         "../libexec/rackup/remote.rkt"
+         "../libexec/rackup/agents-guide.rkt")
 
 (define-runtime-path here ".")
 (define root-dir (simplify-path (build-path here "..")))
@@ -23,6 +25,32 @@
 
 (define tmp-stage (make-temporary-directory))
 (define plt-web-stage (build-path tmp-stage "plt-web-out"))
+
+;; Wrap the CommonMark-rendered guide body in the site chrome.  Reuses
+;; rackup.css and rackup-navbar.js, which the Scribble docs step emits
+;; into out-dir alongside docs.html.
+(define (agents-page-html body-html)
+  (string-append
+   "<!DOCTYPE html>\n"
+   "<html lang=\"en\">\n"
+   "<head>\n"
+   "<meta charset=\"utf-8\">\n"
+   "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+   "<title>rackup for agents</title>\n"
+   "<link rel=\"icon\" type=\"image/svg+xml\" href=\"favicon.svg\">\n"
+   "<link rel=\"stylesheet\" href=\"rackup.css\">\n"
+   "<style>\n"
+   "main.rackup-agents { max-width: 50rem; margin: 1.5rem auto; padding: 0 1.25rem; }\n"
+   "main.rackup-agents pre { overflow-x: auto; padding: 0.75rem 1rem; }\n"
+   "</style>\n"
+   "<script src=\"rackup-navbar.js\" defer></script>\n"
+   "</head>\n"
+   "<body>\n"
+   "<main class=\"rackup-agents\">\n"
+   body-html
+   "\n</main>\n"
+   "</body>\n"
+   "</html>\n"))
 
 (define (run prog . args)
   (unless (apply system*
@@ -126,6 +154,18 @@
    (run (find-executable-path "scribble")
         "--html" "--dest" out-dir "--dest-name" "docs"
         (build-path root-dir "docs" "rackup.scrbl"))
+
+   ;; Generate the agent guide page (agents.html) and the paste-in
+   ;; snippet (agents-snippet.md) from the single-source module
+   ;; libexec/rackup/agents-guide.rkt.  Runs after the Scribble docs step
+   ;; so rackup.css and rackup-navbar.js already exist in out-dir.
+   (call-with-output-file (build-path out-dir "agents.html")
+     (lambda (out)
+       (display (agents-page-html (document->html (string->document agent-guide-text))) out))
+     #:exists 'truncate/replace)
+   (call-with-output-file (build-path out-dir "agents-snippet.md")
+     (lambda (out) (display agent-snippet-text out))
+     #:exists 'truncate/replace)
 
    ;; Copy favicon
    (copy-file (build-path here "favicon.svg") (build-path out-dir "favicon.svg") #t)

--- a/pages/site.rkt
+++ b/pages/site.rkt
@@ -455,6 +455,7 @@ sh install.sh && rm install.sh})
           @tr{@td{@code{rackup prompt}} @td{Print toolchain info for shell prompt}}
           @tr{@td{@code{rackup reshim}} @td{Rebuild shims from installed toolchains}}
           @tr{@td{@code{rackup doctor}} @td{Print diagnostics}}
+          @tr{@td{@code{rackup agents}} @td{Print a guide for AI agents and automation}}
           @tr{@td{@code{rackup init --shell @i{sh}}} @td{Set up shell integration}}
           @tr{@td{@code{rackup self-upgrade}} @td{Upgrade rackup itself}}
           @tr{@td{@code{rackup uninstall}} @td{Remove rackup and all managed state}}

--- a/test/agents-guide.rkt
+++ b/test/agents-guide.rkt
@@ -1,0 +1,52 @@
+#lang racket/base
+
+;; Guards the "rackup for agents" guide (libexec/rackup/agents-guide.rkt)
+;; against drift: every command the guide teaches must still be a real
+;; subcommand, and must actually appear in the guide text.
+
+(require rackunit
+         racket/list
+         racket/string
+         "../libexec/rackup/agents-guide.rkt"
+         "../libexec/rackup/commands-data.rkt")
+
+(define (contains? haystack needle)
+  (regexp-match? (regexp-quote needle) haystack))
+
+(define (in-list? x xs)
+  (and (member x xs) #t))
+
+(module+ test
+  (define command-names (map car rackup-commands))
+
+  ;; The guide and snippet are non-empty strings.
+  (check-true (string? agent-guide-text))
+  (check-true (> (string-length agent-guide-text) 0))
+  (check-true (string? agent-snippet-text))
+  (check-true (> (string-length agent-snippet-text) 0))
+
+  ;; The `agents` command itself is registered (so `rackup agents` and
+  ;; `rackup help agents` dispatch).
+  (check-true (in-list? "agents" command-names) "commands-data.rkt is missing the `agents` subcommand")
+
+  ;; Drift guard: every referenced command is a real subcommand and is
+  ;; actually mentioned in the guide as `rackup <cmd>`.
+  (check-true (pair? agent-guide-referenced-commands))
+  (for ([cmd (in-list agent-guide-referenced-commands)])
+    (check-true (in-list? cmd command-names) (format "guide references unknown command: ~a" cmd))
+    (check-true (contains? agent-guide-text (string-append "rackup " cmd))
+                (format "guide does not mention `rackup ~a`" cmd)))
+
+  ;; No duplicate entries in the referenced-commands list.
+  (check-equal? (length agent-guide-referenced-commands)
+                (length (remove-duplicates agent-guide-referenced-commands))
+                "duplicate entries in agent-guide-referenced-commands")
+
+  ;; The core guidance is present: prefer `rackup run`, avoid `rackup switch`
+  ;; in scripts.
+  (check-true (contains? agent-guide-text "rackup run") "guide should recommend `rackup run`")
+  (check-true (contains? agent-guide-text "rackup switch") "guide should warn about `rackup switch`")
+
+  ;; The snippet points back at the full guide.
+  (check-true (contains? agent-snippet-text "rackup help agents")
+              "snippet should point at `rackup help agents`"))

--- a/test/all.rkt
+++ b/test/all.rkt
@@ -2,7 +2,8 @@
 
 ;; Require the `test` submodules explicitly: requiring just the main
 ;; modules would skip everything wrapped in (module+ test ...).
-(require (submod "checksum.rkt" test)
+(require (submod "agents-guide.rkt" test)
+         (submod "checksum.rkt" test)
          (submod "copy-filtered-tree.rkt" test)
          (submod "env.rkt" test)
          (submod "install-prefix.rkt" test)

--- a/test/e2e-fresh-container.sh
+++ b/test/e2e-fresh-container.sh
@@ -498,6 +498,37 @@ else
 fi
 
 echo
+echo "== Agent-facing command smoke (see 'rackup help agents') =="
+# The agent guide promises these commands work non-interactively and print
+# stable, line-oriented output. Keep this in step with libexec/rackup/agents-guide.rkt.
+run_rackup default "$primary_id"
+
+agents_guide="$(run_rackup help agents)"
+assert_contains "rackup run" "$agents_guide" "'rackup help agents' should print the guide"
+
+ids_out="$(run_rackup list --ids)"
+assert_nonempty "$ids_out" "'rackup list --ids' should list installed toolchain IDs"
+assert_contains "$primary_id" "$ids_out" "'rackup list --ids' should include the primary toolchain"
+
+current_id="$(run_rackup current id)"
+assert_eq "$primary_id" "$current_id" "'rackup current id' should print just the active id"
+
+current_line="$(run_rackup current line)"
+assert_contains "$primary_id" "$current_line" "'rackup current line' should report the active id"
+assert_contains "default" "$current_line" "'rackup current line' should report the source"
+
+default_status="$(run_rackup default status)"
+assert_contains "set" "$default_status" "'rackup default status' should report the default is set"
+assert_contains "$primary_id" "$default_status" "'rackup default status' should include the default id"
+
+which_racket="$(run_rackup which racket)"
+assert_nonempty "$which_racket" "'rackup which racket' should print a path"
+case "$which_racket" in
+  /*) : ;;
+  *) fail "'rackup which racket' should print an absolute path (got '$which_racket')" ;;
+esac
+
+echo
 echo "== Package install / isolation tests =="
 if [[ "$SKIP_PACKAGE_TESTS" == "1" ]]; then
   echo "Skipping package tests for this scenario"


### PR DESCRIPTION
## What

Adds a guide for driving rackup non-interactively — from CI, scripts, or a coding agent — surfaced as `rackup agents` / `rackup help agents`, published on the docs site, and drift-guarded by tests.

## Why

Automation commonly trips over rackup's shell-integration model: `rackup switch` only takes effect through the shell function installed in an interactive `.bashrc`/`.zshrc`, so `rackup switch X && raco …` in a `bash -c` or CI step silently runs the *default* toolchain, not `X`. The guide leads with the correct primitive — `rackup run <toolchain> -- <cmd>` — and documents the line-oriented state commands, exit codes, recipes, and anti-patterns.

## Contents

**`3007e8a` — the command + tests**
- Single-source guide in `libexec/rackup/agents-guide.rkt`, embedded so it works in the prebuilt exe; printed by `rackup agents` and `rackup help agents`, and listed in the top-level help.
- `test/agents-guide.rkt` drift-guards the guide against `commands-data.rkt` (a referenced command that gets renamed/removed fails the test); the container smoke test exercises `help agents`, `list --ids`, `current id`/`line`, `default status`, and `which`.

**`7fa5803` — publish + document**
- Pages build renders `agents.html` and `agents-snippet.md` from the same module (via `commonmark`, added to the Pages workflow deps); navbar gains an "Agents" link; Scribble reference gains a `rackup agents` section; README gains a "For AI agents and automation" section.
- `AGENTS.md` symlinks to `CLAUDE.md` so other coding-agent tools pick up the same contributor rules; `CLAUDE.md` documents the split between contributor docs and the guide for agents using rackup as a tool.

## Testing

`raco test -y test/all.rkt` → **1037 passed**. ShellCheck + shfmt clean on the modified shell script; the Scribble reference builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
