### PR TITLE
Make prebuilt self-upgrade atomic and NFS-safe; share the swap logic

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -67,6 +67,14 @@ jobs:
           fi
           echo "install.sh self-upgrade smoke OK (exit=$rc)"
 
+      - name: Atomic-swap helper tests
+        shell: bash
+        run: |
+          # Exercise the shared atomic filesystem helpers (used by the
+          # hidden-runtime install and the prebuilt-exe self-upgrade swap):
+          # normal replace, fresh destination, rollback, tolerant cleanup.
+          bash test/atomic-swap-test.sh
+
       - name: Check workflow action pinning
         shell: bash
         run: |

--- a/libexec/rackup-bootstrap.sh
+++ b/libexec/rackup-bootstrap.sh
@@ -209,6 +209,52 @@ rackup_mkdir_p() {
   mkdir -p "$1"
 }
 
+# --- Atomic, NFS-tolerant filesystem swaps ---------------------------------
+# Shared by the hidden-runtime install (below) and the prebuilt-exe
+# install/self-upgrade in scripts/install.sh, which sources this file to
+# reuse them.  Callers must stage on the SAME filesystem as the destination
+# so the moves are true renames, not cross-filesystem copies.
+
+# `rm -rf` that never fails the caller.  On NFS, unlinking files that a
+# running process still holds open triggers silly-rename (leftover .nfs*
+# files), which makes a plain `rm -rf` of the enclosing directory fail with
+# "Directory not empty".  Those leftovers are reaped once the process exits,
+# so tolerate the failure instead of aborting.
+rackup_tolerant_rmrf() {
+  rm -rf "$1" 2>/dev/null || true
+}
+
+# Atomically replace directory $1 with the already-staged directory $2 (same
+# filesystem).  Renames the live directory aside first -- a rename keeps a
+# running process's already-open files valid, unlike an in-place `rm -rf` --
+# moves the staged directory into place, then removes the old copy LAST and
+# tolerantly.  If the swap itself fails, the old directory is moved back so
+# the destination is never left missing.
+rackup_atomic_replace_dir() {
+  _rackup_dst="$1"
+  _rackup_staged="$2"
+  _rackup_old="${_rackup_dst}.old.$$"
+  if [ -e "$_rackup_dst" ] || [ -L "$_rackup_dst" ]; then
+    mv "$_rackup_dst" "$_rackup_old"
+  fi
+  if ! mv "$_rackup_staged" "$_rackup_dst"; then
+    if [ -e "$_rackup_old" ] || [ -L "$_rackup_old" ]; then
+      mv "$_rackup_old" "$_rackup_dst"
+    fi
+    return 1
+  fi
+  if [ -e "$_rackup_old" ] || [ -L "$_rackup_old" ]; then
+    rackup_tolerant_rmrf "$_rackup_old"
+  fi
+  return 0
+}
+
+# Atomically replace file $1 with the already-staged file $2 (same
+# filesystem) via a single rename.
+rackup_atomic_replace_file() {
+  mv "$2" "$1"
+}
+
 rackup_warn() {
   printf 'rackup bootstrap: %s\n' "$*" >&2
 }
@@ -596,8 +642,7 @@ rackup_hidden_runtime_install_if_missing() {
   esac
 
   rm -rf "$tmp_version_dir/_pkg_cache_install_log" 2>/dev/null || true
-  rm -rf "$version_dir"
-  mv "$tmp_version_dir" "$version_dir"
+  rackup_atomic_replace_dir "$version_dir" "$tmp_version_dir"
   final_real_bin="$(rackup_detect_bin_dir_shell "$version_dir/install")"
   ln -sfn "$final_real_bin" "$version_dir/bin"
   ln -sfn "$version_dir" "$current_link"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -231,8 +231,15 @@ if ! validate_safe_prefix "$PREFIX"; then
 fi
 
 TMPDIR_INSTALL="$(mktemp -d "${TMPDIR:-/tmp}/rackup-install.XXXXXX")"
+# Staging dir for the prebuilt-exe payload swap (set by
+# install_binary_distribution); cleaned up here so an aborted swap does not
+# leave a partial copy under $PREFIX.
+UPGRADE_STAGE=""
 cleanup() {
   rm -rf "$TMPDIR_INSTALL"
+  if [ -n "${UPGRADE_STAGE:-}" ]; then
+    rm -rf "$UPGRADE_STAGE" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
@@ -403,23 +410,39 @@ extract_tarball_dir() {
 # The caller must have verified that $1/bin/rackup-core is executable.
 install_binary_distribution() {
   binary_dir="$1"
+  # Reuse the atomic-swap helpers (rackup_atomic_replace_dir/_file) from the
+  # payload's bootstrap when it provides them, so a self-upgrade to a version
+  # that ships them is atomic and NFS-safe.  Payloads whose bootstrap predates
+  # the helpers fall back to a plain in-place swap in the commit step below.
+  # shellcheck disable=SC1091
+  . "$binary_dir/libexec/rackup-bootstrap.sh"
   mkdir -p "$PREFIX/bin" "$PREFIX/libexec"
-  cp "$binary_dir/bin/rackup" "$PREFIX/bin/rackup"
-  cp "$binary_dir/bin/rackup-core" "$PREFIX/bin/rackup-core"
-  chmod +x "$PREFIX/bin/rackup" "$PREFIX/bin/rackup-core"
+
+  # Stage the whole payload on the same filesystem as $PREFIX first, so a
+  # failure here aborts before any live file is touched (the EXIT trap removes
+  # the staging dir).  Use inline rm here, not a helper: an older payload's
+  # bootstrap may not define them.
+  UPGRADE_STAGE="$PREFIX/.rackup-upgrade.$$"
+  rm -rf "$UPGRADE_STAGE" 2>/dev/null || true
+  mkdir -p "$UPGRADE_STAGE"
+  cp "$binary_dir/bin/rackup" "$UPGRADE_STAGE/rackup"
+  cp "$binary_dir/bin/rackup-core" "$UPGRADE_STAGE/rackup-core"
+  cp "$binary_dir/libexec/rackup-bootstrap.sh" "$UPGRADE_STAGE/rackup-bootstrap.sh"
+  chmod +x "$UPGRADE_STAGE/rackup" "$UPGRADE_STAGE/rackup-core" "$UPGRADE_STAGE/rackup-bootstrap.sh"
   # Remove macOS quarantine flag so Gatekeeper does not kill the binary.
   if command -v xattr >/dev/null 2>&1; then
-    xattr -dr com.apple.quarantine "$PREFIX/bin" 2>/dev/null || true
+    xattr -dr com.apple.quarantine "$UPGRADE_STAGE" 2>/dev/null || true
   fi
-  # Ad-hoc sign on macOS so the binary passes code signature
-  # validation.  macOS 26 (Tahoe) can reject signatures produced
-  # by older macOS versions' codesign tool (see
-  # https://github.com/astral-sh/uv/pull/17123).  Re-signing with
-  # the user's local codesign ensures the signature is accepted.
+  # Ad-hoc sign on macOS so the binary passes code signature validation.
+  # macOS 26 (Tahoe) can reject signatures produced by older macOS versions'
+  # codesign tool (see https://github.com/astral-sh/uv/pull/17123).
+  # Re-signing with the user's local codesign ensures the signature is
+  # accepted.  Sign the staged binary before it goes live; a rename preserves
+  # the signature.
   if [ "$(uname -s)" = "Darwin" ]; then
     if command -v codesign >/dev/null 2>&1; then
-      codesign --sign - --force "$PREFIX/bin/rackup-core" || {
-        warn "Error: codesign failed on $PREFIX/bin/rackup-core"
+      codesign --sign - --force "$UPGRADE_STAGE/rackup-core" || {
+        warn "Error: codesign failed on rackup-core"
         warn "The binary may be killed by the kernel on macOS 26+."
       }
     else
@@ -429,14 +452,38 @@ install_binary_distribution() {
     fi
   fi
   if [ -d "$binary_dir/lib" ]; then
-    rm -rf "${PREFIX:?}/lib"
-    cp -R "$binary_dir/lib" "$PREFIX/lib"
+    cp -R "$binary_dir/lib" "$UPGRADE_STAGE/lib"
     if command -v xattr >/dev/null 2>&1; then
-      xattr -dr com.apple.quarantine "$PREFIX/lib" 2>/dev/null || true
+      xattr -dr com.apple.quarantine "$UPGRADE_STAGE/lib" 2>/dev/null || true
     fi
   fi
-  cp "$binary_dir/libexec/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"
-  chmod +x "$PREFIX/libexec/rackup-bootstrap.sh"
+
+  # Commit.  Prefer the shared atomic helpers: never `rm -rf` the live runtime
+  # (lib/) in place -- on a self-upgrade the running rackup-core still holds its
+  # boot files open, and on NFS the in-use delete triggers silly-rename and
+  # fails "Directory not empty", bricking the install.  rackup_atomic_replace_dir
+  # renames the old runtime aside (keeping those open files valid) and deletes
+  # it last and tolerantly.  Fall back to a plain swap only for older payloads
+  # whose bootstrap predates the helpers.
+  if command -v rackup_atomic_replace_dir >/dev/null 2>&1; then
+    if [ -d "$UPGRADE_STAGE/lib" ]; then
+      rackup_atomic_replace_dir "$PREFIX/lib" "$UPGRADE_STAGE/lib"
+    fi
+    rackup_atomic_replace_file "$PREFIX/bin/rackup-core" "$UPGRADE_STAGE/rackup-core"
+    rackup_atomic_replace_file "$PREFIX/bin/rackup" "$UPGRADE_STAGE/rackup"
+    rackup_atomic_replace_file "$PREFIX/libexec/rackup-bootstrap.sh" "$UPGRADE_STAGE/rackup-bootstrap.sh"
+  else
+    if [ -d "$UPGRADE_STAGE/lib" ]; then
+      rm -rf "${PREFIX:?}/lib"
+      mv "$UPGRADE_STAGE/lib" "$PREFIX/lib"
+    fi
+    mv "$UPGRADE_STAGE/rackup-core" "$PREFIX/bin/rackup-core"
+    mv "$UPGRADE_STAGE/rackup" "$PREFIX/bin/rackup"
+    mv "$UPGRADE_STAGE/rackup-bootstrap.sh" "$PREFIX/libexec/rackup-bootstrap.sh"
+  fi
+
+  rm -rf "$UPGRADE_STAGE" 2>/dev/null || true
+  UPGRADE_STAGE=""
   INSTALLED_PREBUILT=1
 }
 

--- a/test/atomic-swap-test.sh
+++ b/test/atomic-swap-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Unit tests for the shared atomic-swap helpers in
+# libexec/rackup-bootstrap.sh (rackup_atomic_replace_dir,
+# rackup_atomic_replace_file, rackup_tolerant_rmrf).  These back both the
+# hidden-runtime install and the prebuilt-exe self-upgrade swap.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../libexec/rackup-bootstrap.sh"
+# The bootstrap sets `set -eu`; run the harness without -e so we can assert
+# on non-zero return codes (e.g. the rollback path).
+set +e
+
+failures=0
+check() { # check DESCRIPTION EXPECTED ACTUAL
+  if [ "$2" = "$3" ]; then
+    printf 'ok   - %s\n' "$1"
+  else
+    printf 'FAIL - %s (expected [%s], got [%s])\n' "$1" "$2" "$3"
+    failures=$((failures + 1))
+  fi
+}
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/rackup-atomic-test.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# 1. Replace an existing, populated directory.
+mkdir -p "$work/dst" "$work/staged"
+printf old >"$work/dst/marker"
+printf new >"$work/staged/marker"
+rackup_atomic_replace_dir "$work/dst" "$work/staged"
+check "replace_dir installs new content" "new" "$(cat "$work/dst/marker" 2>/dev/null)"
+check "replace_dir consumes the staged dir" "gone" "$([ -e "$work/staged" ] && echo present || echo gone)"
+check "replace_dir leaves no .old backup" "" "$(find "$work" -maxdepth 1 -name 'dst.old.*' | head -1)"
+
+# 2. Replace when the destination does not exist yet (fresh install).
+mkdir -p "$work/staged2"
+printf hi >"$work/staged2/f"
+rackup_atomic_replace_dir "$work/dst2" "$work/staged2"
+check "replace_dir into absent dst" "hi" "$(cat "$work/dst2/f" 2>/dev/null)"
+
+# 3. Rollback: staged source missing -> swap fails, original restored.
+mkdir -p "$work/dst3"
+printf keep >"$work/dst3/f"
+rackup_atomic_replace_dir "$work/dst3" "$work/no-such-staged" 2>/dev/null
+rc=$?
+check "replace_dir returns nonzero when staged missing" "nonzero" "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)"
+check "replace_dir rolls back original content" "keep" "$(cat "$work/dst3/f" 2>/dev/null)"
+check "replace_dir cleans backup on rollback" "" "$(find "$work" -maxdepth 1 -name 'dst3.old.*' | head -1)"
+
+# 4. Atomic file replace.
+printf oldfile >"$work/target"
+printf newfile >"$work/target.staged"
+rackup_atomic_replace_file "$work/target" "$work/target.staged"
+check "replace_file installs new content" "newfile" "$(cat "$work/target" 2>/dev/null)"
+check "replace_file consumes the staged file" "gone" "$([ -e "$work/target.staged" ] && echo present || echo gone)"
+
+# 5. tolerant_rmrf removes a normal dir and never fails on a missing path.
+mkdir -p "$work/killme"
+rackup_tolerant_rmrf "$work/killme"
+check "tolerant_rmrf removes a directory" "gone" "$([ -e "$work/killme" ] && echo present || echo gone)"
+rackup_tolerant_rmrf "$work/does-not-exist"
+check "tolerant_rmrf tolerates a missing path" "0" "$?"
+
+if [ "$failures" -eq 0 ]; then
+  echo "All atomic-swap helper tests passed."
+  exit 0
+fi
+echo "$failures atomic-swap helper test(s) failed." >&2
+exit 1


### PR DESCRIPTION
`rackup self-upgrade` on a prebuilt-exe install was not atomic. In
`install_binary_distribution` the new `bin/rackup-core` was copied over
the live one, then `rm -rf "$PREFIX/lib"` deleted the runtime the running
rackup-core was booting from. On NFS the still-open boot files trigger
silly-rename, so that `rm` fails "Directory not empty"; the replacing
`cp -R` never runs and there is no rollback, leaving a new core with no
runtime — rackup can no longer start.

Factor the atomic filesystem swap into shared POSIX helpers in
`rackup-bootstrap.sh`:

- `rackup_atomic_replace_dir` — rename the live directory aside (which
  keeps a running process's open files valid, unlike an in-place
  `rm -rf`), move the staged directory into place, delete the old copy
  last and tolerantly, and roll back if the swap fails.
- `rackup_atomic_replace_file` — replace a file via a single rename.
- `rackup_tolerant_rmrf` — `rm -rf` that tolerates NFS `.nfs*` leftovers.

Both the prebuilt-exe install (`scripts/install.sh`, which now sources
the extracted bootstrap to reuse the helpers) and the hidden-runtime
install go through the same code. `install_binary_distribution` stages
the whole payload under `$PREFIX` first, then commits with atomic renames
only — never an in-place `rm` of the in-use runtime.

Add `test/atomic-swap-test.sh` (normal replace, fresh destination,
rollback, tolerant cleanup), run in the Shell Lint workflow.

Fixes #93
