### PR TITLE
Key linked toolchains' compiled dir on installation name, not version

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -142,13 +142,15 @@ The env file exports all variables unconditionally (`PLTADDONDIR`, `PLTCOMPILEDR
 
 ## Per-toolchain PLTCOMPILEDROOTS
 
-Different Racket versions (and CS vs BC) produce incompatible `.zo` bytecode. To prevent cross-version contamination in `compiled/` directories under user source trees, rackup sets `PLTCOMPILEDROOTS` per toolchain so each version+variant writes compiled output to its own subdirectory while preserving access to the toolchain's existing compiled files.
+Different Racket versions (and CS vs BC), and source builds versus installer binaries, produce incompatible `.zo` bytecode. To prevent one toolchain from invalidating another's compiled files in `compiled/` directories under shared user source trees, rackup sets `PLTCOMPILEDROOTS` per toolchain so each **installation** writes compiled output to its own subdirectory while preserving access to the toolchain's existing compiled files. The goal is one compiled directory per installation.
 
 ### How the value is constructed
 
 At toolchain install or link time, `compiled-roots-value` in `state.rkt` constructs a colon-separated PLTCOMPILEDROOTS string:
 
-1. The first entry is `compiled/<version>-<variant>` (e.g., `compiled/9.1-cs`), which is where new `.zo` files are written.
+1. The first entry is the per-installation key, which is where new `.zo` files are written:
+   - **Installer toolchains** have a stable version, so they key on `compiled/<version>-<variant>` (e.g., `compiled/9.1-cs`). This lets `.zo`-compatible variants (full and minimal at the same version) share one directory.
+   - **Linked source toolchains** key on the installation name instead — `compiled/<variant>-local-<name>` (e.g., `compiled/cs-local-dev`). A linked toolchain's version drifts on every `make`, so keying on the version would spawn a fresh compiled tree per rebuild and go stale whenever the source is rebuilt outside `rackup rebuild`. The name is stable across rebuilds and already unique per installation, and it keeps the linked toolchain from sharing a dir with an installer toolchain at the same version+variant.
 2. The remaining entries are the toolchain's existing `compiled-file-roots`, read from its `config.rktd` by `read-toolchain-compiled-file-roots`. This preserves the toolchain's native compiled-file layout:
    - **In-place installs** (rackup's default): existing roots = `(same)`, serialized as `.` → `compiled/9.1-cs:.`
    - **FHS installs** (e.g., setup-racket on CI): existing roots include an absolute reroot path → `compiled/9.1-cs:/usr/lib/racket/compiled:.`
@@ -156,7 +158,7 @@ At toolchain install or link time, `compiled-roots-value` in `state.rkt` constru
 
 The `'same` symbol in `current-compiled-file-roots` cannot be spelled directly in PLTCOMPILEDROOTS because `path-list-string->path-list` converts all entries to path objects. However, `.` is a relative path that `(build-path dir ".")` resolves to `dir` itself, which is functionally equivalent.
 
-For linked toolchains where version or variant cannot be probed, PLTCOMPILEDROOTS is omitted. The value flows through the existing `env-vars` metadata pipeline: `write-toolchain-env-file!` (in `shims.rkt`) emits an unconditional export in env.sh, and `cmd-run` in `main.rkt` preserves a user-restored value before overlaying toolchain env vars.
+A linked toolchain gets a key from its name as long as the variant is known (and, as a last resort, from the name alone). PLTCOMPILEDROOTS is omitted only for an installer toolchain whose version or variant cannot be determined. The value flows through the existing `env-vars` metadata pipeline: `write-toolchain-env-file!` (in `shims.rkt`) emits an unconditional export in env.sh, and `cmd-run` in `main.rkt` preserves a user-restored value before overlaying toolchain env vars.
 
 ### Migration for existing installs
 

--- a/libexec/rackup/state.rkt
+++ b/libexec/rackup/state.rkt
@@ -162,20 +162,33 @@
     [(string? r) r]
     [else (format "~a" r)]))
 
-;; Compute a PLTCOMPILEDROOTS value that prepends a version-variant-
-;; specific subdirectory to the toolchain's existing compiled-file
-;; roots.  `existing-roots` is a list as found in config.rktd's
+;; Compute a PLTCOMPILEDROOTS value that prepends a per-installation
+;; subdirectory to the toolchain's existing compiled-file roots.  The
+;; goal is one compiled directory per installation, so that switching
+;; between toolchains that share a user source tree doesn't invalidate
+;; each other's (mutually incompatible) .zo files.
+;;
+;; `existing-roots` is a list as found in config.rktd's
 ;; 'compiled-file-roots key (e.g., (same) for in-place installs, or
 ;; ("/usr/lib/racket/compiled") for FHS installs).  When not provided,
 ;; defaults to (same).  `local-name` is the local name of a linked
-;; toolchain (e.g., "dev" for `rackup link dev`), and when non-#f is
-;; appended to the key so locally-built toolchains don't share
-;; compiled-file directories with release installs of the same
-;; version+variant.
+;; toolchain (e.g., "dev" for `rackup link dev`).
 ;;
-;; Returns a string like "compiled/9.1-cs:." or
-;; "compiled/9.1-cs-local-dev:." (for linked toolchains), or #f when
-;; the version/variant are too incomplete to form a stable key.
+;; Keying:
+;;  - A linked source toolchain's version drifts on every `make`, so
+;;    keying its dir on the version would spawn a fresh compiled tree
+;;    per rebuild -- and go stale whenever the source is rebuilt outside
+;;    `rackup rebuild`.  Key those on the installation name instead
+;;    (e.g. "compiled/cs-local-dev"), which is stable across rebuilds
+;;    and already unique per installation.
+;;  - Installer toolchains have a stable version, so they keep the
+;;    version+variant key (e.g. "compiled/9.1-cs").  That also lets
+;;    .zo-compatible variants (full/minimal at the same version) share a
+;;    directory.
+;;
+;; Returns a string like "compiled/9.1-cs:." or "compiled/cs-local-dev:."
+;; (for linked toolchains), or #f when there is not enough information to
+;; form a stable key.
 (define (compiled-roots-value version variant [existing-roots '(same)] [local-name #f])
   (define variant-str
     (cond
@@ -187,14 +200,18 @@
       [(and (string? version) (not (string-blank? version)) (not (equal? version "local")))
        version]
       [else #f]))
-  (define local-suffix
+  (define local-name-str
+    (and (string? local-name) (not (string-blank? local-name)) local-name))
+  (define key
     (cond
-      [(and (string? local-name) (not (string-blank? local-name)))
-       (format "-local-~a" local-name)]
-      [else ""]))
+      ;; Linked toolchain: key on the installation name (version-independent).
+      [(and local-name-str variant-str) (format "compiled/~a-local-~a" variant-str local-name-str)]
+      [local-name-str (format "compiled/local-~a" local-name-str)]
+      ;; Installer toolchain: key on the stable version+variant.
+      [(and version-str variant-str) (format "compiled/~a-~a" version-str variant-str)]
+      [else #f]))
   (cond
-    [(and version-str variant-str)
-     (define key (format "compiled/~a-~a~a" version-str variant-str local-suffix))
+    [key
      ;; Always include 'same (serialized as ".") so that user code's
      ;; compiled/ directories are found, even on FHS installs where the
      ;; existing roots only contain absolute reroot paths for system

--- a/test/state-shims.rkt
+++ b/test/state-shims.rkt
@@ -539,12 +539,15 @@
      (check-not-false (member "scheme" (hash-ref linked-meta 'executables)))
      (check-not-false (member "petite" (hash-ref linked-meta 'executables)))
      (check-true (file-exists? (rackup-toolchain-env-file linked-id)))
-     ;; Linked toolchain env.sh should use a local-name-suffixed key so it
-     ;; doesn't share a compiled/<version>-<variant>/ dir with an
-     ;; installer-built toolchain at the same version+variant.
+     ;; Linked toolchain env.sh should key its compiled dir on the
+     ;; installation name (not the version), so it neither shares a
+     ;; compiled/<version>-<variant>/ dir with an installer-built
+     ;; toolchain nor spawns a new dir when the source is rebuilt.
      (let ([env-sh (file->string (rackup-toolchain-env-file linked-id))])
-       (check-true (string-contains? env-sh "compiled/9.99-cs-local-devsrc")
-                   "linked env.sh uses local-name-suffixed compiled dir"))
+       (check-true (string-contains? env-sh "compiled/cs-local-devsrc")
+                   "linked env.sh keys compiled dir on installation name")
+       (check-false (string-contains? env-sh "compiled/9.99")
+                    "linked compiled dir does not encode the version"))
 
      (write-exe "racket"
                 (fake-racket-script
@@ -557,9 +560,13 @@
                      printf 'ARGS=%s\n' "$*"}))
      (check-equal? (link-toolchain! "devsrc" (path->string src-root) '("--force")) linked-id)
      (check-equal? (hash-ref (read-toolchain-meta linked-id) 'resolved-version) "9.98")
+     ;; Even though the probed version changed (9.99 -> 9.98), the compiled
+     ;; dir stays the same: it is keyed on the installation name.
      (let ([env-sh (file->string (rackup-toolchain-env-file linked-id))])
-       (check-true (string-contains? env-sh "compiled/9.98-cs-local-devsrc")
-                   "relinked env.sh uses local-name-suffixed compiled dir"))
+       (check-true (string-contains? env-sh "compiled/cs-local-devsrc")
+                   "relinked env.sh keeps the same name-keyed compiled dir")
+       (check-false (string-contains? env-sh "compiled/9.98")
+                    "relinked compiled dir does not encode the new version"))
 
      (define shim-racket (build-path (rackup-shims-dir) "racket"))
      (define old-pltaddon (getenv "PLTADDONDIR"))
@@ -2006,8 +2013,8 @@
                 "compiled/9.1-cs:/abs/root:."
                 "mixed roots: absolute + same (no duplicate .)")
   (check-equal? (compiled-roots-value "9.1" 'cs '(same) "dev")
-                "compiled/9.1-cs-local-dev:."
-                "linked toolchain: local-name suffix distinguishes from installer")
+                "compiled/cs-local-dev:."
+                "linked toolchain: keyed on installation name, not version")
   (check-equal? (compiled-roots-value "9.1" 'cs '(same) #f)
                 "compiled/9.1-cs:."
                 "no local-name: no suffix")
@@ -2015,13 +2022,24 @@
                 "compiled/9.1-cs:."
                 "blank local-name: no suffix")
   (check-equal? (compiled-roots-value "9.1" 'cs '("/usr/lib/racket/compiled") "dev")
-                "compiled/9.1-cs-local-dev:/usr/lib/racket/compiled:."
-                "linked FHS layout: local-name applies to key only")
+                "compiled/cs-local-dev:/usr/lib/racket/compiled:."
+                "linked FHS layout: name-keyed dir, then existing roots")
+  ;; The key point: a linked toolchain's compiled dir is version-
+  ;; independent, so rebuilding (which bumps the version) reuses one dir
+  ;; instead of spawning a fresh compiled tree per rebuild.
+  (check-equal? (compiled-roots-value "9.1" 'cs '(same) "dev")
+                (compiled-roots-value "9.9.0.7" 'cs '(same) "dev")
+                "linked toolchain compiled key does not change with the version")
+  ;; A linked toolchain still gets a stable key even if the version
+  ;; couldn't be probed, since the name carries the identity.
+  (check-equal? (compiled-roots-value "local" 'cs '(same) "dev")
+                "compiled/cs-local-dev:."
+                "linked toolchain: name-keyed even when version is unknown")
   (check-false (compiled-roots-value "9.1" 'unknown) "variant 'unknown disables")
-  (check-false (compiled-roots-value "local" 'cs) "\"local\" version disables")
-  (check-false (compiled-roots-value #f 'cs) "#f version disables")
-  (check-false (compiled-roots-value "9.1" #f) "#f variant disables")
-  (check-false (compiled-roots-value "" 'cs) "blank version disables")
+  (check-false (compiled-roots-value "local" 'cs) "\"local\" version disables (no name)")
+  (check-false (compiled-roots-value #f 'cs) "#f version disables (no name)")
+  (check-false (compiled-roots-value "9.1" #f) "#f variant disables (installer)")
+  (check-false (compiled-roots-value "" 'cs) "blank version disables (no name)")
 
   ;; Unit tests: env-var-export-line — all vars exported unconditionally
   (check-equal? (env-var-export-line "PLTADDONDIR" "/foo/bar")
@@ -2475,8 +2493,8 @@
                    "reshim updated PLTADDONDIR to probed value")
      (define pcr (assoc "PLTCOMPILEDROOTS" new-env-vars))
      (check-not-false pcr "reshim wrote PLTCOMPILEDROOTS")
-     (check-equal? (cdr pcr) "compiled/9.7.0.5-cs-local-stale:."
-                   "reshim PLTCOMPILEDROOTS uses re-probed version")
+     (check-equal? (cdr pcr) "compiled/cs-local-stale:."
+                   "reshim PLTCOMPILEDROOTS keys on installation name, not the re-probed version")
 
      ;; env.sh should also reflect the new values.
      (define env-sh (file->string (rackup-toolchain-env-file id)))


### PR DESCRIPTION
A linked source toolchain's version drifts on every `make`, so keying its `PLTCOMPILEDROOTS` subdirectory on the version was wrong. On this machine it showed up as `raco setup` reporting a compiled-file root of `compiled/9.2.0.6-cs-local-plt` even though the running racket had moved on to `9.3.0.2` — the recorded key named a version the binary no longer is.

Keying on the version has two failure modes:
- **Stale** — when the source is rebuilt outside `rackup rebuild` (plain `make`), the recorded key keeps naming the old version.
- **Churn** — if kept perfectly fresh, every rebuild would spawn a brand-new `compiled/<new-version>-…/` tree, forcing full recompiles and leaking orphaned version-dirs.

## Fix

Key linked toolchains on the **installation name** instead — `compiled/<variant>-local-<name>` (e.g. `compiled/cs-local-plt`). The name is stable across rebuilds and already unique per installation, so there is **one compiled dir per installation**. This still isolates a linked toolchain from an installer toolchain at the same version+variant (the reason the `-local-<name>` suffix was added in the first place) while never encoding the drifting version.

Installer toolchains keep the version+variant key (`compiled/9.1-cs`): their version is stable, and sharing lets `.zo`-compatible variants (full/minimal at the same version) reuse one directory.

The change is centralized in `compiled-roots-value`, so env.sh generation, reshim, backfill, and `remove --clean-compiled` all inherit it. Existing linked toolchains migrate to the new key on the next reshim via `compute-local-env-vars`.

## Tests

Updated the `compiled-roots-value` unit tests, the relink integration test (now asserts the key is *unchanged* when the probed version changes 9.99→9.98), and the reshim test; added an explicit version-independence assertion. Full suite: 1046 passed.